### PR TITLE
Set default of parser option "relativeUrls" to "true"

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ lib2
 
 Type: `object`
 
-Options for the [less](http://lesscss.org) parser (`less.Parser`).
+Options for the [less](http://lesscss.org) parser (`less.Parser`).  
+**Note:** Default of `relativeUrls` option is changed from `false` to `true`.
 
 ##### compiler
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,11 @@ module.exports.build = function(input, options, callback) {
 		library: {}
 	}, options);
 
+    // Set default of "relativeUrls" parser option to "true" (less default is "false")
+    if (!options.parser.hasOwnProperty("relativeUrls")) {
+        options.parser.relativeUrls = true;
+    }
+
 	var result = {
 		variables: {},
 		css: '',

--- a/test/expected/imports/main-no-relativeUrls.css
+++ b/test/expected/imports/main-no-relativeUrls.css
@@ -3,9 +3,9 @@
 
 /* dir1/foo.less */
 .foo {
-  background: url("dir1/foo.png");
+  background: url("foo.png");
 }
 /* dir2/bar.less */
 .bar {
-  background: url("dir2/bar.png");
+  background: url("bar.png");
 }

--- a/test/fixtures/imports/dir1/foo.less
+++ b/test/fixtures/imports/dir1/foo.less
@@ -1,1 +1,5 @@
 /* dir1/foo.less */
+
+.foo {
+	background: url("foo.png");
+}

--- a/test/fixtures/imports/dir2/bar.less
+++ b/test/fixtures/imports/dir2/bar.less
@@ -1,1 +1,5 @@
 /* dir2/bar.less */
+
+.bar {
+	background: url("bar.png");
+}

--- a/test/test.js
+++ b/test/test.js
@@ -250,6 +250,45 @@ describe('imports', function() {
 
   });
 
+  it('should use "relativeUrls" parser option by default', function(done) {
+
+    lessOpenUI5.build(readFile('test/fixtures/imports/main.less'), {
+      parser: {
+        filename: 'main.less',
+        paths: [ 'test/fixtures/imports' ]
+      }
+    }, function(err, result) {
+
+      assert.ifError(err);
+
+      assert.equal(result.css, readFile('test/expected/imports/main.css'), 'css should be correctly generated.');
+
+      done();
+
+    });
+
+  });
+
+  it('should not rewrite urls when "relativeUrls" parser option is set to "false"', function(done) {
+
+    lessOpenUI5.build(readFile('test/fixtures/imports/main.less'), {
+      parser: {
+        filename: 'main.less',
+        paths: [ 'test/fixtures/imports' ],
+        relativeUrls: false
+      }
+    }, function(err, result) {
+
+      assert.ifError(err);
+
+      assert.equal(result.css, readFile('test/expected/imports/main-no-relativeUrls.css'), 'css should be correctly generated.');
+
+      done();
+
+    });
+
+  });
+
 });
 
 describe('inline theming parameters', function() {


### PR DESCRIPTION
This is a breaking change!
In order to get the old behavior back, please set the
"parser.relativeUrls" option to "false".

As ui5 themes usually import other themes (e.g. base) to inherit
variables, mixins and rules it is required to set the "relativeUrls"
option to "true" in order to generate valid URLs (e.g. images/fonts).

The default in LESS 1.6.3 is "false".