### PR TITLE
BREAKING: Rewrite theme build and support scopes (Belize Themes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,14 @@ npm install less-openui5
 ```js
 var lessOpenUI5 = require('less-openui5');
 
-lessOpenUI5.build({
+// Create a builder instance
+var builder = new lessOpenUI5.Builder();
+
+// Build a theme
+builder.build({
   lessInput: '@var: #ffffff; .class { color: @var; float: left }'
-}, function(err, result) {
+})
+.then(function(result) {
 
   console.log(result.css); // => regular css
   /*
@@ -48,21 +53,40 @@ lessOpenUI5.build({
   []
   */
 
+  // Clear builder cache when finished to cleanup memory
+  builder.clearCache();
+
 });
 ```
 
 ## API
 
-### build(options, callback)
+### new Builder()
+
+Creates a new `Builder` instance.
+
+It caches build results to only rebuild a theme when related files have been changed.  
+This is mainly relevant when building themes as part of a server middleware like [`connect-openui5`](https://github.com/SAP/connect-openui5).
+
+### .build(options)
+Returns a Promise resolving with a [`result`](#result) object.
 
 #### options
 
 ##### lessInput
 
-*Required*  
+*Required (either `lessInput` or `lessInputPath`, not both)*  
 Type: `string`
 
 Input less content.
+
+##### lessInputPath
+
+*Required (either `lessInput` or `lessInputPath`, not both)*  
+Type: `string`
+
+Path to input less file.  
+When `rootPaths` is given this must be a relative path inside one of the provided `rootPaths`, otherwise just a regular filesystem path.
 
 ##### rtl
 
@@ -79,9 +103,6 @@ Root paths to use for import directives.
 
 This option differs from the less `compiler.paths` option.  
 It is useful if less files are located in separate folders but referenced as they would all be in one.  
-If `rootPaths` are provided and a file can not be found, the `compiler.paths` option will be used instead.
-
-*Note:* `parser.filename` has to be set to the path of the `input` file in order to get this working.
 
 ###### Example
 
@@ -128,34 +149,35 @@ Type `string`
 Dot-separated name of the corresponding library.  
 It will be used to inline the `variables` JSON as data-uri which can be retrieved at runtime.
 
-#### callback(error, result)
+#### result
 
-*Required*  
-Type: `function`
-
-##### result.css
+##### css
 
 Type: `string`
 
 Regular css output.
 
-##### result.cssRtl
+##### cssRtl
 
 Type: `string`
 
 Mirrored css for right-to-left support (if rtl option was enabled).
 
-##### result.variables
+##### variables
 
 Type: `object`
 
 Key-value map of all global less variables (without @ prefix).
 
-##### result.imports
+##### imports
 
 Type: `array`
 
 Paths to files imported via import directives.
+
+### .clearCache()
+Clears all cached build results.  
+Use this method to prevent high memory consumption when building many themes within the same process.
 
 ## Contributing
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -1,0 +1,162 @@
+// Copyright 2017 SAP SE.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http: //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+'use strict';
+
+// Regular expression to match type of property in order to check whether
+// it possibly contains color values.
+var rProperties = /(color|background|border|text|outline)(?!\-(width|radius|offset|style|align|overflow|transform))(\-(color|shadow|image))?/;
+
+function selectorEquals(s1, s2) {
+
+	// Make sure there is the same number of select parts
+	if (s1.length !== s2.length) {
+		return false;
+	}
+
+	// Check if all the parts are the same strings
+	for (var i = 0; i < s1.length; i++) {
+		if (s1[i] !== s2[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+function Diffing(oBase, oCompare) {
+	this.oBase = oBase;
+	this.oCompare = oCompare;
+
+	this.oDiff = {
+		type: "stylesheet",
+		stylesheet: {
+			rules: []
+		},
+	};
+
+	this.oStack = {
+		type: "stylesheet",
+		stylesheet: {
+			rules: []
+		},
+	};
+}
+
+Diffing.prototype.diffRules = function(oBaseRules, oCompareRules) {
+	var aDiffRules = [];
+	var iBaseNode, iCompareNode;
+
+	for (iBaseNode = 0, iCompareNode = 0; iBaseNode < oBaseRules.length; iBaseNode++, iCompareNode++) {
+		var oBaseNode = oBaseRules[iBaseNode];
+		var oCompareNode = oCompareRules[iCompareNode];
+		var oDiffNode = null;
+
+		// Add all different compare nodes to stack and check for next one
+		while (oBaseNode.type !== oCompareNode.type) {
+			this.oStack.stylesheet.rules.push(oCompareNode);
+			iCompareNode++;
+			oCompareNode = oCompareRules[iCompareNode];
+		}
+
+		if (oBaseNode.type === "comment") {
+			var sBaseComment = oBaseNode.comment;
+			var sCompareComment = oCompareNode.comment;
+
+			if (sBaseComment !== sCompareComment) {
+				oDiffNode = oCompareNode;
+			}
+		}
+
+		if (oBaseNode.type === "rule") {
+
+			// Add all rules with different selector to stack and check for next one
+			while (!selectorEquals(oBaseNode.selectors, oCompareNode.selectors)) {
+				this.oStack.stylesheet.rules.push(oCompareNode);
+				iCompareNode++;
+				oCompareNode = oCompareRules[iCompareNode];
+			}
+
+			var aBaseDeclarations = oBaseNode.declarations;
+			var aCompareDeclarations = oCompareNode.declarations;
+			for (var j = 0; j < aBaseDeclarations.length; j++) {
+				var oBaseDeclaration = aBaseDeclarations[j];
+				var oCompareDeclaration = aCompareDeclarations[j];
+
+				if (oBaseDeclaration.type === "declaration") {
+
+					// TODO: Also check for different node and add to stack???
+					if (oBaseDeclaration.type === oCompareDeclaration.type) {
+
+						if (oBaseDeclaration.property === oCompareDeclaration.property) {
+
+							// Always add color properties to diff to prevent unexpected CSS overrides
+							// due to selectors with more importance
+							if (oBaseDeclaration.value !== oCompareDeclaration.value
+									|| oCompareDeclaration.property.match(rProperties)) {
+
+								// Add compared rule to diff
+								if (!oDiffNode) {
+									oDiffNode = oCompareNode;
+									oDiffNode.declarations = [];
+								}
+								oDiffNode.declarations.push(oCompareDeclaration);
+							}
+
+						}
+					}
+				}
+			}
+
+		} else if (oBaseNode.type === "media") {
+
+			var aMediaDiffRules = this.diffRules(oBaseNode.rules, oCompareNode.rules);
+
+			if (aMediaDiffRules.length > 0) {
+				oDiffNode = oCompareNode;
+				oDiffNode.rules = aMediaDiffRules;
+			}
+
+		}
+
+		if (oDiffNode) {
+			aDiffRules.push(oDiffNode);
+		}
+
+	}
+
+	// Add all leftover compare nodes to stack
+	for (; iCompareNode < oCompareRules.length; iCompareNode++) {
+		this.oStack.stylesheet.rules.push(oCompareRules[iCompareNode]);
+	}
+
+	return aDiffRules;
+};
+
+Diffing.prototype.run = function() {
+	var oBaseRules = this.oBase.stylesheet.rules;
+	var oCompareRules = this.oCompare.stylesheet.rules;
+
+	this.oDiff.stylesheet.rules = this.diffRules(oBaseRules, oCompareRules);
+
+	return {
+		diff: this.oDiff,
+		stack: this.oStack
+	};
+};
+
+
+module.exports = function diff(oBase, oCompare) {
+	return new Diffing(oBase, oCompare).run();
+};

--- a/lib/fileUtils.js
+++ b/lib/fileUtils.js
@@ -1,0 +1,81 @@
+// Copyright 2017 SAP SE.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http: //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+
+function statFile(filePath) {
+	return new Promise(function(resolve, reject) {
+		fs.stat(filePath, function(err, stat) {
+			// No rejection here as it is ok if the file was not found
+			resolve(stat ? { path: filePath, stat: stat } : null);
+		});
+	});
+}
+
+function statFiles(files) {
+	return Promise.all(files.map(statFile));
+}
+
+function findFile(filePath, rootPaths) {
+	if (rootPaths && rootPaths.length > 0) {
+		return statFiles(
+			rootPaths.map(function(rootPath) {
+				return path.join(rootPath, filePath);
+			})
+		).then(function(results) {
+			for (var i = 0; i < results.length; i++) {
+				if (results[i] !== null) {
+					return results[i];
+				}
+			}
+
+			// File not found
+			return null;
+		});
+	} else {
+		return statFile(filePath);
+	}
+}
+
+function readFile(lessInputPath, rootPaths) {
+	return findFile(lessInputPath, rootPaths).then(function(fileInfo) {
+		if (!fileInfo) {
+			return null;
+		}
+		return new Promise(function(resolve, reject) {
+			fs.readFile(fileInfo.path, {
+				encoding: 'utf8'
+			}, function(fileErr, content) {
+				if (fileErr) {
+					reject(fileErr);
+				} else {
+					resolve({
+						content: content,
+						path: fileInfo.path,
+						localPath: lessInputPath,
+						stats: fileInfo.stats
+					});
+				}
+			});
+		});
+	});
+}
+
+module.exports.statFile = statFile;
+module.exports.statFiles = statFiles;
+module.exports.findFile = findFile;
+module.exports.readFile = readFile;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,25 +14,106 @@
 
 'use strict';
 
-var less = require('less');
 var path = require('path');
 var assign = require('object-assign');
+var clone = require('clone');
+var css = require('css');
+
+var createParser = require('./less/parser');
+var diff = require('./diff');
+var scope = require('./scope');
+
+var fileUtils = require('./fileUtils');
 
 // Plugins
 var RTLPlugin = require('./plugin/rtl');
 var ImportCollectorPlugin = require('./plugin/import-collector');
 var VariableCollectorPlugin = require('./plugin/variable-collector');
 
-/**
- * Compiles the provided LESS string to CSS using the less compiler.
- *
- * @param {Object} options An object with build options
- * @param {Function} callback Function to call when finished.
- */
-module.exports.build = function(options, callback) {
+// Workaround for a performance issue in the "css" parser module when used in combination
+// with the "colors" module that enhances the String prototype.
+// See: https://github.com/reworkcss/css/issues/88
+//
+// This function removes all properties added by "colors" and returns a function
+// that restores them  afterwards.
+// To be used before/after calling "css.parse"
+function cleanupStringPrototype() {
+	var customProps = {}, s = "";
 
+	for (var key in s) {
+		if (!s.hasOwnProperty(key)) {
+			customProps[key] = String.prototype.__lookupGetter__(key);
+			Reflect.deleteProperty(String.prototype, key);
+		}
+	}
+
+	return function restore() {
+		for (var key in customProps) {
+			if (customProps.hasOwnProperty(key)) {
+				String.prototype.__defineGetter__(key, customProps[key]);
+			}
+		}
+	}
+}
+
+function dotThemingFileToPath(s) {
+	if (s.indexOf(".") > -1) {
+		s = "../" + s.replace(/\./g, "/");
+	}
+
+	return s;
+}
+
+var Builder = function() {
+	this.themeCacheMapping = {};
+};
+
+Builder.prototype.getThemeCache = function(rootPath) {
+	return this.themeCacheMapping[rootPath];
+};
+
+Builder.prototype.setThemeCache = function(rootPath, cache) {
+	return this.themeCacheMapping[rootPath] = cache;
+};
+
+Builder.prototype.clearCache = function() {
+	this.themeCacheMapping = {};
+}
+
+Builder.prototype.cacheTheme = function(result) {
+	var that = this;
+	var rootpath;
+
+	// Theme can only be cached if list of imports is available
+	if (result.imports.length === 0) {
+		return Promise.resolve(result);
+	}
+
+	// Rootpath of theme is always the first entry
+	rootpath = result.imports[0];
+
+	return fileUtils.statFiles(result.imports).then(function(stats) {
+		that.setThemeCache(rootpath, {
+			result: result,
+			stats: stats
+		});
+
+		return result;
+	});
+
+};
+
+Builder.prototype.build = function(options) {
+	var that = this;
+
+	// Stores mapping between "virtual" paths (used within LESS) and real filesystem paths.
+	// Only relevant when using the "rootPaths" option.
+	var mFileMappings = {};
+
+	// Assign default options
 	options = assign({
 		lessInput: null,
+		lessInputPath: null,
 		rtl: true,
 		rootPaths: [],
 		parser: {},
@@ -45,56 +126,72 @@ module.exports.build = function(options, callback) {
 		options.parser.relativeUrls = true;
 	}
 
-	var result = {
-		variables: {},
-		css: '',
-		tree: null
-	};
+	function fileHandler(file, currentFileInfo, handleDataAndCallCallback, callback) {
 
-	var rootPathsMapping = {};
+		var pathname = path.normalize(currentFileInfo.currentDirectory + file);
 
-	// Keep reference of original less function
-	var fnFileLoader = less.Parser.fileLoader;
-	less.Parser.fileLoader = function fileLoaderHook(file, currentFileInfo, fn, env) {
-		var paths = rootPathsMapping[currentFileInfo.currentDirectory];
-		if (typeof paths === 'undefined') {
-			var base = options.rootPaths.filter(function(p) {
-				p = path.normalize(p);
-				return path.normalize(currentFileInfo.currentDirectory).substr(0, p.length) === p;
-			})[0];
-			if (base) {
-				var suffix = path.relative(base, currentFileInfo.currentDirectory);
-				paths = options.rootPaths.map(function(p) {
-					return path.join(p, suffix);
-				});
+		fileUtils.readFile(pathname, options.rootPaths).then(function(result) {
+			if (!result) {
+				console.log("File not found");
+				callback({ type: 'File', message: "'" + file + "' wasn't found" })
 			} else {
-				paths = null; // set paths to null to identify if dir has already been checked
+
+				try {
+					// Save import mapping to calculate full import paths later on
+					mFileMappings[currentFileInfo.rootFilename] = mFileMappings[currentFileInfo.rootFilename] || {};
+					mFileMappings[currentFileInfo.rootFilename][pathname] = result.path;
+
+					handleDataAndCallCallback(pathname, result.content);
+				} catch (e) {
+					console.log(e);
+					callback(e);
+				}
+
 			}
-			rootPathsMapping[currentFileInfo.currentDirectory] = paths;
-		}
-		if (paths) {
-			env.paths = paths;
-		} else if (options.parser.paths) {
-			env.paths = options.parser.paths;
-		}
-		return fnFileLoader.apply(this, arguments);
-	};
+		}, function(err) {
+			console.log(err);
+			callback(err);
+		});
+	}
 
-	var parser = new less.Parser(options.parser);
+	function compile(config) {
+		return new Promise(function(resolve, reject) {
 
-	parser.parse(options.lessInput, function(err, tree) {
+			var parserOptions = clone(options.parser);
+			var rootpath;
 
-		// restore fileLoader function
-		less.Parser.fileLoader = fnFileLoader;
+			if (config.path) {
+				// Keep rootpath for later usage in the ImportCollectorPlugin
+				rootpath = config.path;
+				parserOptions.filename = config.localPath;
+			}
 
-		result.tree = tree;
+			// Keep filename for later usage (see ImportCollectorPlugin) as less modifies the parserOptions.filename
+			var filename = parserOptions.filename;
 
-		if (!err) {
+			// Only use custom file handler when "rootPaths" are defined
+			var fnFileHandler;
+			if (options.rootPaths && options.rootPaths.length > 0) {
+				fnFileHandler = fileHandler;
+			}
 
-			try {
+			var parser = createParser(parserOptions, fnFileHandler);
+
+			parser.parse(config.content, function(err, tree) {
+
+				if (err) {
+					reject(err);
+					return;
+				}
+
+				var result = {};
+
+				result.tree = tree;
 
 				// plugins to collect imported files and variable values
-				var oImportCollector = new ImportCollectorPlugin();
+				var oImportCollector = new ImportCollectorPlugin({
+					importMappings: mFileMappings[filename]
+				});
 				var oVariableCollector = new VariableCollectorPlugin();
 
 				// render to css
@@ -104,6 +201,8 @@ module.exports.build = function(options, callback) {
 
 				// retrieve imported files
 				result.imports = oImportCollector.getImports();
+
+				// retrieve imported variables
 				result.variables = oVariableCollector.getVariables();
 
 				// also compile rtl-version if requested
@@ -113,35 +212,238 @@ module.exports.build = function(options, callback) {
 					}));
 				}
 
-				if (typeof options.library === "object" && typeof options.library.name === "string") {
-					var parameters = JSON.stringify(result.variables);
-
-					// escape all chars that could cause problems with css parsers using URI-Encoding (% + HEX-Code)
-					var escapedChars = "%{}()'\"\\";
-					for (var i = 0; i < escapedChars.length; i++) {
-						var char = escapedChars.charAt(i);
-						var hex = char.charCodeAt(0).toString(16).toUpperCase();
-						parameters = parameters.replace(new RegExp("\\" + char, "g"), "%" + hex);
-					}
-
-					var parameterStyleRule =
-						"\n/* Inline theming parameters */\n#sap-ui-theme-" +
-						options.library.name.replace(/\./g, "\\.") +
-						" { background-image: url('data:text/plain;utf-8," + parameters + "'); }\n";
-
-					// embed parameter variables as plain-text string into css
-					result.css += parameterStyleRule;
-					if (result.cssRtl) {
-						result.cssRtl += parameterStyleRule;
-					}
+				if (rootpath) {
+					result.imports.unshift(rootpath);
 				}
 
-			} catch (ex) {
-				err = ex;
+				resolve(result);
+
+			});
+		});
+	}
+
+	function addInlineParameters(result) {
+		return new Promise(function(resolve, reject) {
+			if (typeof options.library === "object" && typeof options.library.name === "string") {
+				var parameters = JSON.stringify(result.variables);
+
+				// escape all chars that could cause problems with css parsers using URI-Encoding (% + HEX-Code)
+				var escapedChars = "%{}()'\"\\";
+				for (var i = 0; i < escapedChars.length; i++) {
+					var char = escapedChars.charAt(i);
+					var hex = char.charCodeAt(0).toString(16).toUpperCase();
+					parameters = parameters.replace(new RegExp("\\" + char, "g"), "%" + hex);
+				}
+
+				var parameterStyleRule =
+					"\n/* Inline theming parameters */\n#sap-ui-theme-" +
+					options.library.name.replace(/\./g, "\\.") +
+					" { background-image: url('data:text/plain;utf-8," + parameters + "'); }\n";
+
+				// embed parameter variables as plain-text string into css
+				result.css += parameterStyleRule;
+				if (result.cssRtl) {
+					result.cssRtl += parameterStyleRule;
+				}
+			}
+			resolve(result);
+		});
+	}
+
+	function readDotTheming(dotThemingInputPath) {
+		return fileUtils.readFile(dotThemingInputPath, options.rootPaths).then(function(result) {
+
+			var dotTheming;
+			var dotThemingFilePath;
+
+			if (result) {
+				dotTheming = JSON.parse(result.content);
+				dotThemingFilePath = result.path;
 			}
 
-		}
+			if (dotTheming && dotTheming.mCssScopes) {
 
-		callback(err, result);
-	});
+				// Currently only the "library" target is supported
+				var cssScope = dotTheming.mCssScopes["library"];
+
+				if (cssScope) {
+
+					var aScopes = cssScope.aScopes;
+					var oScopeConfig = aScopes[0]; // Currenlty only one scope is supported
+
+					var sBaseFile = dotThemingFileToPath(cssScope.sBaseFile || cssScopeTarget);
+					var sEmbeddedCompareFile = dotThemingFileToPath(oScopeConfig.sEmbeddedCompareFile);
+					var sEmbeddedFile = dotThemingFileToPath(oScopeConfig.sEmbeddedFile);
+
+					// Currently, only support the use case when "sBaseFile" equals "sEmbeddedCompareFile"
+					if (sBaseFile !== sEmbeddedCompareFile) {
+						throw new Error("Unsupported content in \"" + dotThemingInputPath + "\": " +
+							"\"sBaseFile\" (\"" + (cssScope.sBaseFile || cssScopeTarget) + "\") must be identical with " +
+							"\"sEmbeddedCompareFile\" (\"" + oScopeConfig.sEmbeddedCompareFile + "\")");
+					}
+
+					var embeddedCompareFilePath = path.posix.join(themeDir, sEmbeddedCompareFile) + '.source.less';
+					var embeddedFilePath = path.posix.join(themeDir, sEmbeddedFile) + '.source.less';
+
+					// 1. Compile base + embedded files (both default + RTL variants)
+					return Promise.all([
+						fileUtils.readFile(embeddedCompareFilePath, options.rootPaths).then(compile),
+						fileUtils.readFile(embeddedFilePath, options.rootPaths).then(compile)
+					]).then(function(results) {
+						return {
+							embeddedCompare: results[0],
+							embedded: results[1]
+						};
+					}).then(function(results) {
+
+						// baseFile or embeddedFile
+						var sLibraryBaseFile = dotTheming.mCssScopes.library.sBaseFile;
+						var sScopeName = oScopeConfig.sSelector;
+
+						function applyScope(embeddedCompareCss, embeddedCss, bRtl) {
+
+							var restoreStringPrototype = cleanupStringPrototype();
+
+							// Create diff object between embeddedCompare and embedded
+							var oBase = css.parse(embeddedCompareCss);
+							var oEmbedded = css.parse(embeddedCss);
+
+							restoreStringPrototype();
+
+							var oDiff = diff(oBase, oEmbedded);
+
+							// Create scope
+							var sScopeSelector = '.' + sScopeName;
+							var oScope = scope(oDiff.diff, sScopeSelector);
+
+							var oCssScopeRoot;
+
+							if (oDiff.stack) {
+								oCssScopeRoot = scope.scopeCssRoot(oDiff.stack.stylesheet.rules, sScopeName);
+
+								if (oCssScopeRoot) {
+									oScope.stylesheet.rules.unshift(oCssScopeRoot);
+								}
+							}
+
+							// Append scope + stack to embeddedCompareFile (actually target file, which is currently always the same i.e. "library.css")
+							// The stack gets appended to the embeddedFile only
+							var sAppend = css.stringify(oScope);
+
+							if (sLibraryBaseFile !== "library" && oDiff.stack && oDiff.stack.stylesheet.rules.length > 0) {
+								sAppend +=  "\n" + css.stringify(oDiff.stack);
+							}
+
+							return sAppend + "\n";
+
+						}
+
+						results.embeddedCompare.css += applyScope(results.embeddedCompare.css, results.embedded.css);
+						if (options.rtl) {
+							results.embeddedCompare.cssRtl += applyScope(results.embeddedCompare.cssRtl, results.embedded.cssRtl, true);
+						}
+
+						// Create diff between embeddedCompare and embeded variables
+						var oVariablesBase = results.embeddedCompare.variables;
+						var oVariablesEmbedded = results.embedded.variables;
+						var oVariablesDiff = {};
+
+						for (var sKey in oVariablesEmbedded) {
+							if (sKey in oVariablesBase) {
+								if (oVariablesBase[sKey] != oVariablesEmbedded[sKey]) {
+									oVariablesDiff[sKey] = oVariablesEmbedded[sKey];
+								}
+							}
+						}
+
+						// Merge variables
+						var oVariables = {};
+						oVariables["default"] = oVariablesBase;
+						oVariables["scopes"] = {};
+						oVariables["scopes"][sScopeName] = oVariablesDiff;
+
+						results.embeddedCompare.variables = oVariables;
+
+						var concatImports = function(aImportsBase, aImportsEmbedded) {
+							var aConcats = aImportsBase.concat(aImportsEmbedded);
+
+							return aConcats.filter(function(sImport, sIndex) {
+								return aConcats.indexOf(sImport) == sIndex;
+							})
+						};
+
+						if (sLibraryBaseFile !== "library") {
+							results.embeddedCompare.imports = concatImports(results.embedded.imports, results.embeddedCompare.imports);
+						} else {
+							results.embeddedCompare.imports = concatImports(results.embeddedCompare.imports, results.embedded.imports);
+						}
+
+						// add .theming file to result.embeddedCompare.imports
+						results.embeddedCompare.imports.push(dotThemingFilePath);
+
+						// 6. Resolve promise with complete result object (css, cssRtl, variables, imports)
+						return results.embeddedCompare;
+
+					});
+				}
+			}
+
+			// No css diffing and scoping
+			return fileUtils.readFile(options.lessInputPath, options.rootPaths).then(compile);
+		});
+	}
+
+	if (options.lessInput && options.lessInputPath) {
+		return Promise.reject(new Error("Please only provide either `lessInput` or `lessInputPath` but not both."));
+	}
+
+	if (!options.lessInput && !options.lessInputPath) {
+		return Promise.reject(new Error("Missing required option. Please provide either `lessInput` or `lessInputPath`."));
+	}
+
+	if (options.lessInput) {
+
+		return compile({
+			content: options.lessInput
+		}).then(addInlineParameters).then(that.cacheTheme.bind(that));
+
+	} else {
+		var themeDir = path.posix.dirname(options.lessInputPath);
+
+		// Always use the sap/ui/core library to lookup .theming files
+		var coreThemeDir = themeDir.replace(/^.*\/themes\//, "/sap/ui/core/themes/");
+		var dotThemingInputPath = path.posix.join(coreThemeDir, '.theming');
+
+		return fileUtils.findFile(options.lessInputPath, options.rootPaths).then(function(fileInfo) {
+
+			if (!fileInfo) {
+				throw new Error("`lessInputPath` " + options.lessInputPath + " could not be found.");
+			}
+
+			// check theme has been already cached
+			var themeCache;
+			if (fileInfo.path) {
+				themeCache = that.getThemeCache(fileInfo.path);
+			}
+
+			// Compile theme if not cached or RTL is requested and missing in cache
+			if (!themeCache || (options.rtl && !themeCache.result.cssRtl)) {
+				return readDotTheming(dotThemingInputPath).then(addInlineParameters).then(that.cacheTheme.bind(that));
+			} else {
+				return fileUtils.statFiles(themeCache.result.imports).then(function(newStats) {
+					for (var i = 0; i < newStats.length; i++) {
+						// check if .theming and less files have changed since last less compilation
+						if (!newStats[i] || newStats[i].stat.mtime.getTime() !== themeCache.stats[i].stat.mtime.getTime()) {
+							return readDotTheming(dotThemingInputPath).then(addInlineParameters).then(that.cacheTheme.bind(that));
+						}
+					}
+
+					// serve from cache
+					return themeCache.result;
+				});
+			}
+		});
+	}
 };
+
+module.exports.Builder = Builder;

--- a/lib/less/fileLoader.js
+++ b/lib/less/fileLoader.js
@@ -1,0 +1,67 @@
+/*!
+ * LESS - Leaner CSS v1.6.3
+ * http://lesscss.org
+ *
+ * Copyright (c) 2009-2014, Alexis Sellier <self@cloudhead.net>
+ * Licensed under the Apache v2 License.
+ *
+ *
+ * This file contains a modified version of the function "less.Parser.fileLoader"
+ * which has been taken from LESS v1.6.3 (https://github.com/less/less.js/blob/v1.6.3/lib/less/index.js#L127-L233).
+ * Modifications are marked with comments in the code.
+ *
+ */
+
+'use strict';
+
+module.exports = function createFileLoader(fileHandler) {
+	return function fileLoader(file, currentFileInfo, callback, env) {
+
+		/* BEGIN MODIFICATION */
+
+		// Removed unused variables "dirname, data"
+		var pathname,
+			newFileInfo = {
+				relativeUrls: env.relativeUrls,
+				entryPath: currentFileInfo.entryPath,
+				rootpath: currentFileInfo.rootpath,
+				rootFilename: currentFileInfo.rootFilename
+			};
+
+		/* END MODIFICATION */
+
+		function handleDataAndCallCallback(data) {
+			var j = file.lastIndexOf('/');
+
+			// Pass on an updated rootpath if path of imported file is relative and file
+			// is in a (sub|sup) directory
+			//
+			// Examples:
+			// - If path of imported file is 'module/nav/nav.less' and rootpath is 'less/',
+			//   then rootpath should become 'less/module/nav/'
+			// - If path of imported file is '../mixins.less' and rootpath is 'less/',
+			//   then rootpath should become 'less/../'
+			if (newFileInfo.relativeUrls && !/^(?:[a-z-]+:|\/)/.test(file) && j != -1) {
+				var relativeSubDirectory = file.slice(0, j+1);
+				newFileInfo.rootpath = newFileInfo.rootpath + relativeSubDirectory; // append (sub|sup) directory path of imported file
+			}
+			newFileInfo.currentDirectory = pathname.replace(/[^\\\/]*$/, "");
+			newFileInfo.filename = pathname;
+
+			callback(null, data, pathname, newFileInfo);
+		}
+
+		/* BEGIN MODIFICATION */
+
+		// Call custom function to handle file loading
+		fileHandler(file, currentFileInfo, function(resolvedPathname, data) {
+			pathname = resolvedPathname;
+			handleDataAndCallCallback(data);
+		}, callback);
+
+		// The remainder of this function has been completely removed
+
+		/* END MODIFICATION */
+
+	};
+};

--- a/lib/less/importsPush.js
+++ b/lib/less/importsPush.js
@@ -1,0 +1,83 @@
+/*!
+ * LESS - Leaner CSS v1.6.3
+ * http://lesscss.org
+ *
+ * Copyright (c) 2009-2014, Alexis Sellier <self@cloudhead.net>
+ * Licensed under the Apache v2 License.
+ *
+ *
+ * This file contains a modified version of the local function "imports.push" within the constructor of "less.Parser"
+ * which has been taken from LESS v1.6.3 (https://github.com/less/less.js/blob/v1.6.3/lib/less/parser.js#L70-L111).
+ * Modifications are marked with comments in the code.
+ *
+ */
+
+/* eslint-disable consistent-this, new-cap */
+'use strict';
+
+var less = require('less');
+var tree = less.tree;
+
+module.exports = function createImportsPushFunction(env, fileLoader, parserFactory) {
+	return function importsPush(path, currentFileInfo, importOptions, callback) {
+		var parserImports = this;
+		this.queue.push(path);
+
+		var fileParsedFunc = function (e, root, fullPath) {
+			parserImports.queue.splice(parserImports.queue.indexOf(path), 1); // Remove the path from the queue
+
+			/* BEGIN MODIFICATION */
+
+			// Replaced "rootFilename" with "env.filename"
+			var importedPreviously = fullPath in parserImports.files || fullPath === env.filename;
+
+			/* END MODIFICATION */
+
+			parserImports.files[fullPath] = root;                        // Store the root
+
+			if (e && !parserImports.error) { parserImports.error = e; }
+
+			callback(e, root, importedPreviously, fullPath);
+		};
+
+		if (less.Parser.importer) {
+			less.Parser.importer(path, currentFileInfo, fileParsedFunc, env);
+		} else {
+
+			/* BEGIN MODIFICATION */
+
+			// Call custom fileLoader instead of "less.Parser.fileLoader"
+			fileLoader(path, currentFileInfo, function(e, contents, fullPath, newFileInfo) {
+
+			/* END MODIFICATION */
+
+				if (e) {fileParsedFunc(e); return;}
+
+				var newEnv = new tree.parseEnv(env);
+
+				newEnv.currentFileInfo = newFileInfo;
+				newEnv.processImports = false;
+				newEnv.contents[fullPath] = contents;
+
+				if (currentFileInfo.reference || importOptions.reference) {
+					newFileInfo.reference = true;
+				}
+
+				if (importOptions.inline) {
+					fileParsedFunc(null, contents, fullPath);
+				} else {
+
+					/* BEGIN MODIFICATION */
+
+					// Create custom parser when resolving imports
+					parserFactory(newEnv, fileLoader).parse(contents, function (e, root) {
+
+					/* END MODIFICATION */
+
+						fileParsedFunc(e, root, fullPath);
+					});
+				}
+			}, env);
+		}
+	};
+};

--- a/lib/less/parser.js
+++ b/lib/less/parser.js
@@ -1,0 +1,52 @@
+// Copyright 2017 SAP SE.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http: //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+/* eslint-disable new-cap */
+'use strict';
+
+var less = require('less');
+var createFileLoader = require('./fileLoader');
+var createImportsPushFunction = require('./importsPush');
+
+function parserFactory(env, fileLoader) {
+	// Make sure that provided "env" is an instance
+	if (!(env instanceof less.tree.parseEnv)) {
+		env = new less.tree.parseEnv(env);
+	}
+
+	var parser = new less.Parser(env);
+
+	if (fileLoader) {
+		patchParserImportsPush(parser, env, fileLoader);
+	}
+
+	return parser;
+}
+
+function patchParserImportsPush(parser, env, fileLoader) {
+	// Hooks into the parser to be able to use custom file loader and use custom
+	// parser factory for imports
+	parser.imports.push = createImportsPushFunction(env, fileLoader, parserFactory);
+}
+
+module.exports = function createParser(env, fileHandler) {
+
+	// Create fileLoader function if a fileHandler is provided
+	var fileLoader;
+	if (fileHandler) {
+		fileLoader = createFileLoader(fileHandler);
+	}
+
+	return parserFactory(env, fileLoader);
+};

--- a/lib/plugin/import-collector.js
+++ b/lib/plugin/import-collector.js
@@ -16,11 +16,14 @@
 
 var less = require('less');
 
-var ImportCollector = module.exports = function() {
+var ImportCollector = module.exports = function(options) {
 	/*eslint-disable new-cap */
 	this.oVisitor = new less.tree.visitor(this);
 	/*eslint-enable new-cap */
+
 	this.aImports = [];
+
+	this.mImportMappings = options && options.importMappings ? options.importMappings : {};
 };
 
 ImportCollector.prototype = {
@@ -30,7 +33,12 @@ ImportCollector.prototype = {
 	},
 	visitImport: function(importNode, visitArgs) {
 		if (importNode.importedFilename) {
-			this.aImports.push(importNode.importedFilename);
+			var fullImportPath = this.mImportMappings[importNode.importedFilename];
+			if (fullImportPath) {
+				this.aImports.push(fullImportPath);
+			} else {
+				this.aImports.push(importNode.importedFilename);
+			}
 		}
 	},
 	getImports: function() {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,0 +1,154 @@
+// Copyright 2017 SAP SE.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http: //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+'use strict';
+
+/**
+ * DOM-Elements like html, body as CSS selector needs be handled differently in
+ * the scoping. Those selectors will be identified by matching the respective
+ * regEx.
+ */
+var rRegex = /(html[^\s]*|body[^\s]*)/;
+
+var rPoint = /(^\s?\.{1}\w*)/;
+
+function handleScoping(sSelector, sScopeName) {
+
+	/**
+	 * Match the selector to regex, by splitting into two array elements,
+	 * where the first element is the resulting matching group.
+	 */
+	var aCaptureGroups = sSelector.split(rRegex);
+
+	var aSelectors = [];
+	var sSelector1, sSelector2;
+
+	// filter empty strings and undefined objects
+	var aMatch = aCaptureGroups.filter(function(n) {
+		return !!n;
+	});
+
+	if (aMatch.length > 1) {
+		// set scope name after matching group.
+		sSelector1 = aMatch[0] + " " + sScopeName + (aMatch[1] || "");
+
+		// match rPoint to check if following capture group
+		// starts with a css class or dom element
+		if (aMatch[1].match(rPoint)) {
+			sSelector2 = aMatch[0] + " " + sScopeName +
+				aMatch[1].replace(/\s/, '');
+		} else {
+			// no match, selector is a dom element
+			sSelector2 = null;
+		}
+	} else {
+		// match if capture group starts with css rule
+		if (aMatch[0].match(rPoint)) {
+			// set scope before selector
+			sSelector1 = sScopeName + aMatch[0];
+			sSelector2 = sScopeName + " " + aMatch[0];
+		} else {
+			// if selector matches custom css rule
+			if (aMatch[0].match(rRegex)) {
+				sSelector1 = aMatch[0] + sScopeName;
+				sSelector2 = aMatch[0] + " " + sScopeName;
+			} else {
+				// DOM element, add space
+				sSelector1 = sScopeName + " " + aMatch[0];
+				sSelector2 = null;
+			}
+		}
+	}
+
+	aSelectors.push(sSelector1);
+	aSelectors.push(sSelector2);
+
+	return aSelectors;
+}
+
+function Scoping(oSheet, sScopeName) {
+	this.oSheet = oSheet;
+	this.sScopeName = sScopeName;
+}
+
+Scoping.prototype.scopeRules = function(oRules) {
+
+	for (var iNode = 0; iNode < oRules.length; iNode++) {
+		var oNode = oRules[iNode];
+
+		if (oNode.type === "rule") {
+
+			var aNewSelectors = [];
+
+			for (var i = 0; i < oNode.selectors.length; i++) {
+				var sSelector = oNode.selectors[i];
+				var sSelector2;
+
+				if (!(sSelector.match(/.sapContrast/))) {
+
+					var aScopedSelectors = handleScoping(sSelector, this.sScopeName);
+					sSelector = (aScopedSelectors[0] ? aScopedSelectors[0] : sSelector);
+					sSelector2 = (aScopedSelectors[1] ? aScopedSelectors[1] : null);
+
+					aNewSelectors.push(sSelector);
+					if (sSelector2) {
+						aNewSelectors.push(sSelector2);
+					}
+				}
+
+			}
+
+			if (aNewSelectors.length > 0) {
+				oNode.selectors = aNewSelectors;
+			}
+
+		} else if (oNode.type === "media") {
+			this.scopeRules(oNode.rules);
+		}
+	}
+
+};
+
+Scoping.prototype.run = function() {
+	this.scopeRules(this.oSheet.stylesheet.rules);
+	return this.oSheet;
+};
+
+
+module.exports = function scope(oSheet, sScopeName) {
+	return new Scoping(oSheet, sScopeName).run();
+};
+
+module.exports.scopeCssRoot = function scopeCssRoot(oRules, sScopeName) {
+
+	for (var iNode = 0; iNode < oRules.length; iNode++) {
+		var oNode = oRules[iNode];
+
+		if (oNode.type === "rule") {
+
+			for (var i = 0; i < oNode.selectors.length; i++) {
+				var sSelector = oNode.selectors[i];
+
+				if (sSelector.match(/#CSS_SCOPE_ROOT\b/)) {
+					oNode.selectors[i] = "." + sScopeName;
+
+					oRules.splice(iNode, 1);
+
+					return oNode;
+				}
+
+			}
+		}
+	}
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "eslint lib test",
     "unit": "mocha test/*.js",
+    "unit-debug": "mocha --inspect --debug-brk test/*.js",
     "test": "npm run lint && npm run unit"
   },
   "main": "lib/index.js",
@@ -24,10 +25,13 @@
     "node": ">= 0.12.0"
   },
   "dependencies": {
+    "clone": "^2.1.0",
+    "css": "^2.2.1",
     "less": "1.6.3",
     "object-assign": "^4.0.1"
   },
   "devDependencies": {
+    "clean-css": "^3.4.23",
     "eslint": "^1.10.3",
     "mocha": "^3.2.0"
   }

--- a/test/expected/libraries/lib1/my/ui/lib/themes/base/library-RTL.css
+++ b/test/expected/libraries/lib1/my/ui/lib/themes/base/library-RTL.css
@@ -1,0 +1,9 @@
+.myUiLibRule1 {
+  color: #fefefe;
+}
+.myUiLibRule2 {
+  padding: 1px 4px 3px 2px;
+}
+
+/* Inline theming parameters */
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22color1%22:%22#fefefe%22%7D'); }

--- a/test/expected/libraries/lib1/my/ui/lib/themes/base/library.css
+++ b/test/expected/libraries/lib1/my/ui/lib/themes/base/library.css
@@ -1,0 +1,9 @@
+.myUiLibRule1 {
+  color: #fefefe;
+}
+.myUiLibRule2 {
+  padding: 1px 2px 3px 4px;
+}
+
+/* Inline theming parameters */
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22color1%22:%22#fefefe%22%7D'); }

--- a/test/expected/libraries/lib1/my/ui/lib/themes/foo/library-RTL.css
+++ b/test/expected/libraries/lib1/my/ui/lib/themes/foo/library-RTL.css
@@ -1,0 +1,13 @@
+.myUiLibRule1 {
+  color: #ffffff;
+}
+.myUiLibRule2 {
+  padding: 1px 4px 3px 2px;
+}
+.fooContrast.myUiLibRule1,
+.fooContrast .myUiLibRule1 {
+  color: #000000;
+}
+
+/* Inline theming parameters */
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22#ffffff%22%7D,%22scopes%22:%7B%22fooContrast%22:%7B%22color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/libraries/lib1/my/ui/lib/themes/foo/library.css
+++ b/test/expected/libraries/lib1/my/ui/lib/themes/foo/library.css
@@ -1,0 +1,13 @@
+.myUiLibRule1 {
+  color: #ffffff;
+}
+.myUiLibRule2 {
+  padding: 1px 2px 3px 4px;
+}
+.fooContrast.myUiLibRule1,
+.fooContrast .myUiLibRule1 {
+  color: #000000;
+}
+
+/* Inline theming parameters */
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22#ffffff%22%7D,%22scopes%22:%7B%22fooContrast%22:%7B%22color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/libraries/lib2/my/ui/lib/themes/bar/library-RTL.css
+++ b/test/expected/libraries/lib2/my/ui/lib/themes/bar/library-RTL.css
@@ -1,0 +1,13 @@
+.myUiLibRule1 {
+  color: #ffffff;
+}
+.myUiLibRule2 {
+  padding: 1px 4px 3px 2px;
+}
+.barContrast.myUiLibRule1,
+.barContrast .myUiLibRule1 {
+  color: #000000;
+}
+
+/* Inline theming parameters */
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22#ffffff%22%7D,%22scopes%22:%7B%22barContrast%22:%7B%22color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/libraries/lib2/my/ui/lib/themes/bar/library.css
+++ b/test/expected/libraries/lib2/my/ui/lib/themes/bar/library.css
@@ -1,0 +1,13 @@
+.myUiLibRule1 {
+  color: #ffffff;
+}
+.myUiLibRule2 {
+  padding: 1px 2px 3px 4px;
+}
+.barContrast.myUiLibRule1,
+.barContrast .myUiLibRule1 {
+  color: #000000;
+}
+
+/* Inline theming parameters */
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22#ffffff%22%7D,%22scopes%22:%7B%22barContrast%22:%7B%22color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/libraries/scopes/comments/lib1/comments/themes/foo/library-RTL.css
+++ b/test/expected/libraries/scopes/comments/lib1/comments/themes/foo/library-RTL.css
@@ -1,0 +1,13 @@
+/**
+ * This is a sample comment!
+ */
+.myRule1 {
+  /**
+	* This is a sample comment inside a rule!
+	*/
+  color: #000000;
+}
+.fooContrast.myRule1,
+.fooContrast .myRule1 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/comments/lib1/comments/themes/foo/library.css
+++ b/test/expected/libraries/scopes/comments/lib1/comments/themes/foo/library.css
@@ -1,0 +1,13 @@
+/**
+ * This is a sample comment!
+ */
+.myRule1 {
+  /**
+	* This is a sample comment inside a rule!
+	*/
+  color: #000000;
+}
+.fooContrast.myRule1,
+.fooContrast .myRule1 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/comments/lib2/comments/themes/bar/library-RTL.css
+++ b/test/expected/libraries/scopes/comments/lib2/comments/themes/bar/library-RTL.css
@@ -1,0 +1,13 @@
+/**
+ * This is a sample comment!
+ */
+.myRule1 {
+  /**
+	* This is a sample comment inside a rule!
+	*/
+  color: #000000;
+}
+.barContrast.myRule1,
+.barContrast .myRule1 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/comments/lib2/comments/themes/bar/library.css
+++ b/test/expected/libraries/scopes/comments/lib2/comments/themes/bar/library.css
@@ -1,0 +1,13 @@
+/**
+ * This is a sample comment!
+ */
+.myRule1 {
+  /**
+	* This is a sample comment inside a rule!
+	*/
+  color: #000000;
+}
+.barContrast.myRule1,
+.barContrast .myRule1 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/css-scope-root/lib1/css-scope-root/themes/foo/library-RTL.css
+++ b/test/expected/libraries/scopes/css-scope-root/lib1/css-scope-root/themes/foo/library-RTL.css
@@ -1,0 +1,19 @@
+.myRule1 {
+  color: #000000;
+}
+.myRule2 {
+  color: #c3c3c3;
+}
+.fooContrast {
+  color: #aaaaaa;
+}
+
+.fooContrast.myRule1,
+.fooContrast .myRule1 {
+  color: #ffffff;
+}
+
+.fooContrast.myRule2,
+.fooContrast .myRule2 {
+  color: #444444;
+}

--- a/test/expected/libraries/scopes/css-scope-root/lib1/css-scope-root/themes/foo/library.css
+++ b/test/expected/libraries/scopes/css-scope-root/lib1/css-scope-root/themes/foo/library.css
@@ -1,0 +1,19 @@
+.myRule1 {
+  color: #000000;
+}
+.myRule2 {
+  color: #c3c3c3;
+}
+.fooContrast {
+  color: #aaaaaa;
+}
+
+.fooContrast.myRule1,
+.fooContrast .myRule1 {
+  color: #ffffff;
+}
+
+.fooContrast.myRule2,
+.fooContrast .myRule2 {
+  color: #444444;
+}

--- a/test/expected/libraries/scopes/css-scope-root/lib2/css-scope-root/themes/bar/library-RTL.css
+++ b/test/expected/libraries/scopes/css-scope-root/lib2/css-scope-root/themes/bar/library-RTL.css
@@ -1,0 +1,19 @@
+.myRule1 {
+  color: #000000;
+}
+.myRule2 {
+  color: #c3c3c3;
+}
+.barContrast {
+  color: #aaaaaa;
+}
+
+.barContrast.myRule1,
+.barContrast .myRule1 {
+  color: #ffffff;
+}
+
+.barContrast.myRule2,
+.barContrast .myRule2 {
+  color: #444444;
+}

--- a/test/expected/libraries/scopes/css-scope-root/lib2/css-scope-root/themes/bar/library.css
+++ b/test/expected/libraries/scopes/css-scope-root/lib2/css-scope-root/themes/bar/library.css
@@ -1,0 +1,19 @@
+.myRule1 {
+  color: #000000;
+}
+.myRule2 {
+  color: #c3c3c3;
+}
+.barContrast {
+  color: #aaaaaa;
+}
+
+.barContrast.myRule1,
+.barContrast .myRule1 {
+  color: #ffffff;
+}
+
+.barContrast.myRule2,
+.barContrast .myRule2 {
+  color: #444444;
+}

--- a/test/expected/libraries/scopes/default/lib1/default/themes/foo/library-RTL.css
+++ b/test/expected/libraries/scopes/default/lib1/default/themes/foo/library-RTL.css
@@ -1,0 +1,40 @@
+.myRule1 {
+  color: #000000;
+}
+.myRule2 {
+  color: #ffffff;
+  float: right;
+}
+.myRule3 {
+  display: -webkit-flex;
+  display: flex;
+}
+.myRule4 {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+.myRule5,
+.myRule6,
+.myRule7 {
+  color: #000000;
+}
+.fooContrast.myRule1,
+.fooContrast .myRule1 {
+  color: #ffffff;
+}
+
+.fooContrast.myRule2,
+.fooContrast .myRule2 {
+  color: #ffffff;
+}
+
+.fooContrast.myRule5,
+.fooContrast .myRule5,
+.fooContrast.myRule6,
+.fooContrast .myRule6,
+.fooContrast.myRule7,
+.fooContrast .myRule7 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/default/lib1/default/themes/foo/library.css
+++ b/test/expected/libraries/scopes/default/lib1/default/themes/foo/library.css
@@ -1,0 +1,40 @@
+.myRule1 {
+  color: #000000;
+}
+.myRule2 {
+  color: #ffffff;
+  float: left;
+}
+.myRule3 {
+  display: -webkit-flex;
+  display: flex;
+}
+.myRule4 {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+.myRule5,
+.myRule6,
+.myRule7 {
+  color: #000000;
+}
+.fooContrast.myRule1,
+.fooContrast .myRule1 {
+  color: #ffffff;
+}
+
+.fooContrast.myRule2,
+.fooContrast .myRule2 {
+  color: #ffffff;
+}
+
+.fooContrast.myRule5,
+.fooContrast .myRule5,
+.fooContrast.myRule6,
+.fooContrast .myRule6,
+.fooContrast.myRule7,
+.fooContrast .myRule7 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/default/lib2/default/themes/bar/library-RTL.css
+++ b/test/expected/libraries/scopes/default/lib2/default/themes/bar/library-RTL.css
@@ -1,0 +1,43 @@
+.myRule1 {
+  color: #000000;
+}
+.myRule2 {
+  color: #ffffff;
+  float: right;
+}
+.myRule3 {
+  display: -webkit-flex;
+  display: flex;
+}
+.myRule4 {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+.myRule5,
+.myRule6,
+.myRule7 {
+  color: #000000;
+}
+.barContrast.myRule1,
+.barContrast .myRule1 {
+  color: #ffffff;
+}
+
+.barContrast.myRule2,
+.barContrast .myRule2 {
+  color: #ffffff;
+}
+
+.barContrast.myRule5,
+.barContrast .myRule5,
+.barContrast.myRule6,
+.barContrast .myRule6,
+.barContrast.myRule7,
+.barContrast .myRule7 {
+  color: #ffffff;
+}
+.myRule8 {
+  display: block;
+}

--- a/test/expected/libraries/scopes/default/lib2/default/themes/bar/library.css
+++ b/test/expected/libraries/scopes/default/lib2/default/themes/bar/library.css
@@ -1,0 +1,43 @@
+.myRule1 {
+  color: #000000;
+}
+.myRule2 {
+  color: #ffffff;
+  float: left;
+}
+.myRule3 {
+  display: -webkit-flex;
+  display: flex;
+}
+.myRule4 {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+.myRule5,
+.myRule6,
+.myRule7 {
+  color: #000000;
+}
+.barContrast.myRule1,
+.barContrast .myRule1 {
+  color: #ffffff;
+}
+
+.barContrast.myRule2,
+.barContrast .myRule2 {
+  color: #ffffff;
+}
+
+.barContrast.myRule5,
+.barContrast .myRule5,
+.barContrast.myRule6,
+.barContrast .myRule6,
+.barContrast.myRule7,
+.barContrast .myRule7 {
+  color: #ffffff;
+}
+.myRule8 {
+  display: block;
+}

--- a/test/expected/libraries/scopes/dom/lib1/dom/themes/foo/library-RTL.css
+++ b/test/expected/libraries/scopes/dom/lib1/dom/themes/foo/library-RTL.css
@@ -1,0 +1,13 @@
+div.myRule1 {
+  color: #000000;
+}
+div.myRule1 > .myRule2 {
+  color: #000000;
+}
+.fooContrast div.myRule1 {
+  color: #ffffff;
+}
+
+.fooContrast div.myRule1 > .myRule2 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/dom/lib1/dom/themes/foo/library.css
+++ b/test/expected/libraries/scopes/dom/lib1/dom/themes/foo/library.css
@@ -1,0 +1,13 @@
+div.myRule1 {
+  color: #000000;
+}
+div.myRule1 > .myRule2 {
+  color: #000000;
+}
+.fooContrast div.myRule1 {
+  color: #ffffff;
+}
+
+.fooContrast div.myRule1 > .myRule2 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/dom/lib2/dom/themes/bar/library-RTL.css
+++ b/test/expected/libraries/scopes/dom/lib2/dom/themes/bar/library-RTL.css
@@ -1,0 +1,13 @@
+div.myRule1 {
+  color: #000000;
+}
+div.myRule1 > .myRule2 {
+  color: #000000;
+}
+.barContrast div.myRule1 {
+  color: #ffffff;
+}
+
+.barContrast div.myRule1 > .myRule2 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/dom/lib2/dom/themes/bar/library.css
+++ b/test/expected/libraries/scopes/dom/lib2/dom/themes/bar/library.css
@@ -1,0 +1,13 @@
+div.myRule1 {
+  color: #000000;
+}
+div.myRule1 > .myRule2 {
+  color: #000000;
+}
+.barContrast div.myRule1 {
+  color: #ffffff;
+}
+
+.barContrast div.myRule1 > .myRule2 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/empty-media-queries/lib1/empty-media-queries/themes/foo/library-RTL.css
+++ b/test/expected/libraries/scopes/empty-media-queries/lib1/empty-media-queries/themes/foo/library-RTL.css
@@ -1,0 +1,12 @@
+.myRule1 {
+  color: #000000;
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .myRule1 {
+    width: 100px;
+  }
+}
+.fooContrast.myRule1,
+.fooContrast .myRule1 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/empty-media-queries/lib1/empty-media-queries/themes/foo/library.css
+++ b/test/expected/libraries/scopes/empty-media-queries/lib1/empty-media-queries/themes/foo/library.css
@@ -1,0 +1,12 @@
+.myRule1 {
+  color: #000000;
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .myRule1 {
+    width: 100px;
+  }
+}
+.fooContrast.myRule1,
+.fooContrast .myRule1 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/empty-media-queries/lib2/empty-media-queries/themes/bar/library-RTL.css
+++ b/test/expected/libraries/scopes/empty-media-queries/lib2/empty-media-queries/themes/bar/library-RTL.css
@@ -1,0 +1,12 @@
+.myRule1 {
+  color: #000000;
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .myRule1 {
+    width: 100px;
+  }
+}
+.barContrast.myRule1,
+.barContrast .myRule1 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/empty-media-queries/lib2/empty-media-queries/themes/bar/library.css
+++ b/test/expected/libraries/scopes/empty-media-queries/lib2/empty-media-queries/themes/bar/library.css
@@ -1,0 +1,12 @@
+.myRule1 {
+  color: #000000;
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .myRule1 {
+    width: 100px;
+  }
+}
+.barContrast.myRule1,
+.barContrast .myRule1 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/html/lib1/html/themes/foo/library-RTL.css
+++ b/test/expected/libraries/scopes/html/lib1/html/themes/foo/library-RTL.css
@@ -1,0 +1,55 @@
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid td > .sapUiFormTitle {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid td > .sapUiFormTitle {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .testClass {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie] .fooContrast .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .fooContrast.sapUiGrid th > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie] .fooContrast .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .fooContrast.sapUiGrid td > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ed] .fooContrast .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .fooContrast.sapUiGrid th > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ed] .fooContrast .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .fooContrast.sapUiGrid td > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid .fooContrast th > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid .fooContrast td > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid .fooContrast th > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid .fooContrast td > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .fooContrast .testClass,
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .fooContrast.testClass {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/html/lib1/html/themes/foo/library.css
+++ b/test/expected/libraries/scopes/html/lib1/html/themes/foo/library.css
@@ -1,0 +1,37 @@
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid td > .sapUiFormTitle {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid td > .sapUiFormTitle {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .testClass {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie] .fooContrast .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .fooContrast.sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .fooContrast .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .fooContrast.sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .fooContrast .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .fooContrast.sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .fooContrast .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .fooContrast.sapUiGrid td > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid .fooContrast th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid .fooContrast td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid .fooContrast th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid .fooContrast td > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .fooContrast .testClass,
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .fooContrast.testClass {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/html/lib2/html/themes/bar/library-RTL.css
+++ b/test/expected/libraries/scopes/html/lib2/html/themes/bar/library-RTL.css
@@ -1,0 +1,37 @@
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid td > .sapUiFormTitle {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid td > .sapUiFormTitle {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .testClass {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie] .barContrast .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .barContrast.sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .barContrast .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .barContrast.sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .barContrast .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .barContrast.sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .barContrast .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .barContrast.sapUiGrid td > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid .barContrast th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid .barContrast td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid .barContrast th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid .barContrast td > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .barContrast .testClass,
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .barContrast.testClass {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/html/lib2/html/themes/bar/library.css
+++ b/test/expected/libraries/scopes/html/lib2/html/themes/bar/library.css
@@ -1,0 +1,37 @@
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid td > .sapUiFormTitle {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid td > .sapUiFormTitle {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .testClass {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie] .barContrast .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .barContrast.sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .barContrast .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .barContrast.sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .barContrast .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .barContrast.sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .barContrast .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .barContrast.sapUiGrid td > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid .barContrast th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid .barContrast td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid .barContrast th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid .barContrast td > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .barContrast .testClass,
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .barContrast.testClass {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/media-queries/lib1/media-queries/themes/foo/library-RTL.css
+++ b/test/expected/libraries/scopes/media-queries/lib1/media-queries/themes/foo/library-RTL.css
@@ -1,0 +1,45 @@
+@font-face {
+  font-family: 'myfont';
+  src: url('font.eot');
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .myRule1 {
+    color: #000000;
+  }
+  .myRule2 {
+    color: #ffffff;
+  }
+  .myRule3 {
+    display: -webkit-flex;
+    display: flex;
+  }
+  .sapMALI {
+    display: -webkit-box;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+  .sapMALI .sapMLIBUnread,
+  .sapMALI .sapMLIBSelectS,
+  .sapMALI .sapMLIBSelectM,
+  .sapMALI .sapMLIBSelectD {
+    display: none;
+  }
+  .sapMALI {
+    height: 3rem;
+  }
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .fooContrast.myRule1,
+  .fooContrast .myRule1 {
+    color: #ffffff;
+  }
+
+  .fooContrast.myRule2,
+  .fooContrast .myRule2 {
+    color: #ffffff;
+  }
+}

--- a/test/expected/libraries/scopes/media-queries/lib1/media-queries/themes/foo/library.css
+++ b/test/expected/libraries/scopes/media-queries/lib1/media-queries/themes/foo/library.css
@@ -1,0 +1,45 @@
+@font-face {
+  font-family: 'myfont';
+  src: url('font.eot');
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .myRule1 {
+    color: #000000;
+  }
+  .myRule2 {
+    color: #ffffff;
+  }
+  .myRule3 {
+    display: -webkit-flex;
+    display: flex;
+  }
+  .sapMALI {
+    display: -webkit-box;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+  .sapMALI .sapMLIBUnread,
+  .sapMALI .sapMLIBSelectS,
+  .sapMALI .sapMLIBSelectM,
+  .sapMALI .sapMLIBSelectD {
+    display: none;
+  }
+  .sapMALI {
+    height: 3rem;
+  }
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .fooContrast.myRule1,
+  .fooContrast .myRule1 {
+    color: #ffffff;
+  }
+
+  .fooContrast.myRule2,
+  .fooContrast .myRule2 {
+    color: #ffffff;
+  }
+}

--- a/test/expected/libraries/scopes/media-queries/lib2/media-queries/themes/bar/library-RTL.css
+++ b/test/expected/libraries/scopes/media-queries/lib2/media-queries/themes/bar/library-RTL.css
@@ -1,0 +1,45 @@
+@font-face {
+  font-family: 'myfont';
+  src: url('font.eot');
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .myRule1 {
+    color: #000000;
+  }
+  .myRule2 {
+    color: #ffffff;
+  }
+  .myRule3 {
+    display: -webkit-flex;
+    display: flex;
+  }
+  .sapMALI {
+    display: -webkit-box;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+  .sapMALI .sapMLIBUnread,
+  .sapMALI .sapMLIBSelectS,
+  .sapMALI .sapMLIBSelectM,
+  .sapMALI .sapMLIBSelectD {
+    display: none;
+  }
+  .sapMALI {
+    height: 3rem;
+  }
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .barContrast.myRule1,
+  .barContrast .myRule1 {
+    color: #ffffff;
+  }
+
+  .barContrast.myRule2,
+  .barContrast .myRule2 {
+    color: #ffffff;
+  }
+}

--- a/test/expected/libraries/scopes/media-queries/lib2/media-queries/themes/bar/library.css
+++ b/test/expected/libraries/scopes/media-queries/lib2/media-queries/themes/bar/library.css
@@ -1,0 +1,45 @@
+@font-face {
+  font-family: 'myfont';
+  src: url('font.eot');
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .myRule1 {
+    color: #000000;
+  }
+  .myRule2 {
+    color: #ffffff;
+  }
+  .myRule3 {
+    display: -webkit-flex;
+    display: flex;
+  }
+  .sapMALI {
+    display: -webkit-box;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: flex;
+  }
+  .sapMALI .sapMLIBUnread,
+  .sapMALI .sapMLIBSelectS,
+  .sapMALI .sapMLIBSelectM,
+  .sapMALI .sapMLIBSelectD {
+    display: none;
+  }
+  .sapMALI {
+    height: 3rem;
+  }
+}
+@media (min-width: 600px) and (max-width: 1023px) {
+  .barContrast.myRule1,
+  .barContrast .myRule1 {
+    color: #ffffff;
+  }
+
+  .barContrast.myRule2,
+  .barContrast .myRule2 {
+    color: #ffffff;
+  }
+}

--- a/test/expected/libraries/scopes/mixins/lib1/mixins/themes/foo/library-RTL.css
+++ b/test/expected/libraries/scopes/mixins/lib1/mixins/themes/foo/library-RTL.css
@@ -1,0 +1,20 @@
+@media screen and (min-width: 600px) {
+  body {
+    background: #000000;
+    font-size: 21px;
+  }
+  html.myRule1 td {
+    color: #000000;
+  }
+}
+@media screen and (min-width: 600px) {
+  body.fooContrast,
+  body .fooContrast {
+    background: #ffffff;
+    font-size: 20px;
+  }
+
+  html.myRule1 .fooContrast td {
+    color: #ffffff;
+  }
+}

--- a/test/expected/libraries/scopes/mixins/lib1/mixins/themes/foo/library.css
+++ b/test/expected/libraries/scopes/mixins/lib1/mixins/themes/foo/library.css
@@ -1,0 +1,20 @@
+@media screen and (min-width: 600px) {
+  body {
+    background: #000000;
+    font-size: 21px;
+  }
+  html.myRule1 td {
+    color: #000000;
+  }
+}
+@media screen and (min-width: 600px) {
+  body.fooContrast,
+  body .fooContrast {
+    background: #ffffff;
+    font-size: 20px;
+  }
+
+  html.myRule1 .fooContrast td {
+    color: #ffffff;
+  }
+}

--- a/test/expected/libraries/scopes/mixins/lib2/mixins/themes/bar/library-RTL.css
+++ b/test/expected/libraries/scopes/mixins/lib2/mixins/themes/bar/library-RTL.css
@@ -1,0 +1,34 @@
+@media screen and (min-width: 600px) {
+  body {
+    background: #000000;
+    font-size: 21px;
+  }
+  html.myRule1 td {
+    color: #000000;
+  }
+}
+@media screen and (min-width: 600px) {
+  body.barContrast,
+  body .barContrast {
+    background: #ffffff;
+    font-size: 20px;
+  }
+
+  html.myRule1 .barContrast td {
+    color: #ffffff;
+  }
+}
+.myRule2 {
+  background: #ffffff;
+}
+
+@media screen and (min-width: 600px) {
+  body {
+    background: #ffffff;
+    font-size: 20px;
+  }
+
+  .myRule2 {
+    background: #ffffff;
+  }
+}

--- a/test/expected/libraries/scopes/mixins/lib2/mixins/themes/bar/library.css
+++ b/test/expected/libraries/scopes/mixins/lib2/mixins/themes/bar/library.css
@@ -1,0 +1,34 @@
+@media screen and (min-width: 600px) {
+  body {
+    background: #000000;
+    font-size: 21px;
+  }
+  html.myRule1 td {
+    color: #000000;
+  }
+}
+@media screen and (min-width: 600px) {
+  body.barContrast,
+  body .barContrast {
+    background: #ffffff;
+    font-size: 20px;
+  }
+
+  html.myRule1 .barContrast td {
+    color: #ffffff;
+  }
+}
+.myRule2 {
+  background: #ffffff;
+}
+
+@media screen and (min-width: 600px) {
+  body {
+    background: #ffffff;
+    font-size: 20px;
+  }
+
+  .myRule2 {
+    background: #ffffff;
+  }
+}

--- a/test/expected/libraries/scopes/multiple-imports/lib1/multiple-imports/themes/foo/library-RTL.css
+++ b/test/expected/libraries/scopes/multiple-imports/lib1/multiple-imports/themes/foo/library-RTL.css
@@ -1,0 +1,21 @@
+.myRule1 {
+  color: #ffffff;
+}
+.myRule2 {
+  display: block;
+}
+.myRule5 {
+  color: #ffffff;
+}
+.myRule6 {
+  display: block;
+}
+.fooContrast.myRule1,
+.fooContrast .myRule1 {
+  color: #ffffff;
+}
+
+.fooContrast.myRule5,
+.fooContrast .myRule5 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/multiple-imports/lib1/multiple-imports/themes/foo/library.css
+++ b/test/expected/libraries/scopes/multiple-imports/lib1/multiple-imports/themes/foo/library.css
@@ -1,0 +1,21 @@
+.myRule1 {
+  color: #ffffff;
+}
+.myRule2 {
+  display: block;
+}
+.myRule5 {
+  color: #ffffff;
+}
+.myRule6 {
+  display: block;
+}
+.fooContrast.myRule1,
+.fooContrast .myRule1 {
+  color: #ffffff;
+}
+
+.fooContrast.myRule5,
+.fooContrast .myRule5 {
+  color: #ffffff;
+}

--- a/test/expected/libraries/scopes/multiple-imports/lib2/multiple-imports/themes/bar/library-RTL.css
+++ b/test/expected/libraries/scopes/multiple-imports/lib2/multiple-imports/themes/bar/library-RTL.css
@@ -1,0 +1,32 @@
+.myRule1 {
+  color: #ffffff;
+}
+.myRule2 {
+  display: block;
+}
+.myRule5 {
+  color: #ffffff;
+}
+.myRule6 {
+  display: block;
+}
+.barContrast.myRule1,
+.barContrast .myRule1 {
+  color: #ffffff;
+}
+
+.barContrast.myRule5,
+.barContrast .myRule5 {
+  color: #ffffff;
+}
+.myRule3 {
+  color: red;
+}
+
+.myRule4 {
+  background-color: transparent !important;
+}
+
+.myRule7 {
+  color: red;
+}

--- a/test/expected/libraries/scopes/multiple-imports/lib2/multiple-imports/themes/bar/library.css
+++ b/test/expected/libraries/scopes/multiple-imports/lib2/multiple-imports/themes/bar/library.css
@@ -1,0 +1,32 @@
+.myRule1 {
+  color: #ffffff;
+}
+.myRule2 {
+  display: block;
+}
+.myRule5 {
+  color: #ffffff;
+}
+.myRule6 {
+  display: block;
+}
+.barContrast.myRule1,
+.barContrast .myRule1 {
+  color: #ffffff;
+}
+
+.barContrast.myRule5,
+.barContrast .myRule5 {
+  color: #ffffff;
+}
+.myRule3 {
+  color: red;
+}
+
+.myRule4 {
+  background-color: transparent !important;
+}
+
+.myRule7 {
+  color: red;
+}

--- a/test/fixtures/libraries/lib1/my/ui/lib/themes/base/library.source.less
+++ b/test/fixtures/libraries/lib1/my/ui/lib/themes/base/library.source.less
@@ -1,0 +1,9 @@
+@color1: #fefefe;
+
+.myUiLibRule1 {
+  color: @color1;
+}
+
+.myUiLibRule2 {
+  padding: 1px 2px 3px 4px;
+}

--- a/test/fixtures/libraries/lib1/my/ui/lib/themes/foo/library.source.less
+++ b/test/fixtures/libraries/lib1/my/ui/lib/themes/foo/library.source.less
@@ -1,0 +1,3 @@
+@import "../base/library.source.less";
+
+@color1: #ffffff;

--- a/test/fixtures/libraries/lib1/sap/ui/core/themes/foo/.theming
+++ b/test/fixtures/libraries/lib1/sap/ui/core/themes/foo/.theming
@@ -1,0 +1,14 @@
+{
+  "mCssScopes": {
+    "library": {
+      "sBaseFile": "library",
+      "aScopes": [
+        {
+          "sSelector": "fooContrast",
+          "sEmbeddedFile": "bar.library",
+          "sEmbeddedCompareFile": "library"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/libraries/lib2/my/ui/lib/themes/bar/library.source.less
+++ b/test/fixtures/libraries/lib2/my/ui/lib/themes/bar/library.source.less
@@ -1,0 +1,3 @@
+@import "../foo/library.source.less";
+
+@color1: #000000;

--- a/test/fixtures/libraries/lib2/sap/ui/core/themes/bar/.theming
+++ b/test/fixtures/libraries/lib2/sap/ui/core/themes/bar/.theming
@@ -1,0 +1,14 @@
+{
+  "mCssScopes": {
+    "library": {
+      "sBaseFile": "foo.library",
+      "aScopes": [
+        {
+          "sSelector": "barContrast",
+          "sEmbeddedFile": "library",
+          "sEmbeddedCompareFile": "foo.library"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/libraries/scopes/comments/lib1/comments/themes/foo/library.source.less
+++ b/test/fixtures/libraries/scopes/comments/lib1/comments/themes/foo/library.source.less
@@ -1,0 +1,10 @@
+/**
+ * This is a sample comment!
+ */
+
+.myRule1 {
+	/**
+	* This is a sample comment inside a rule!
+	*/
+	color: #000000;
+}

--- a/test/fixtures/libraries/scopes/comments/lib2/comments/themes/bar/library.source.less
+++ b/test/fixtures/libraries/scopes/comments/lib2/comments/themes/bar/library.source.less
@@ -1,0 +1,11 @@
+/**
+ * This is a sample comment!
+ */
+
+.myRule1 {
+	/**
+	* This is a sample comment inside a rule
+	* with a different color value!
+	*/
+	color: #ffffff;
+}

--- a/test/fixtures/libraries/scopes/css-scope-root/lib1/css-scope-root/themes/foo/library.source.less
+++ b/test/fixtures/libraries/scopes/css-scope-root/lib1/css-scope-root/themes/foo/library.source.less
@@ -1,0 +1,7 @@
+.myRule1 {
+	color: #000000;
+}
+
+.myRule2 {
+	color: #c3c3c3;
+}

--- a/test/fixtures/libraries/scopes/css-scope-root/lib2/css-scope-root/themes/bar/library.source.less
+++ b/test/fixtures/libraries/scopes/css-scope-root/lib2/css-scope-root/themes/bar/library.source.less
@@ -1,0 +1,11 @@
+.myRule1 {
+  color: #ffffff;
+}
+
+#CSS_SCOPE_ROOT {
+  color: #aaaaaa;
+}
+
+.myRule2 {
+  color: #444444;
+}

--- a/test/fixtures/libraries/scopes/default/lib1/default/themes/foo/library.source.less
+++ b/test/fixtures/libraries/scopes/default/lib1/default/themes/foo/library.source.less
@@ -1,0 +1,24 @@
+.myRule1 {
+  color: #000000;
+}
+
+.myRule2 {
+  color: #ffffff;
+	float: left;
+}
+
+.myRule3 {
+  display: -webkit-flex;
+  display: flex;
+}
+
+.myRule4 {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.myRule5, .myRule6, .myRule7 {
+  color: #000000;
+}

--- a/test/fixtures/libraries/scopes/default/lib2/default/themes/bar/library.source.less
+++ b/test/fixtures/libraries/scopes/default/lib2/default/themes/bar/library.source.less
@@ -1,0 +1,28 @@
+.myRule1 {
+  color: #ffffff;
+}
+
+.myRule2 {
+  color: #ffffff;
+	float: left;
+}
+
+.myRule3 {
+  display: -webkit-flex;
+  display: flex;
+}
+
+.myRule4 {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.myRule5, .myRule6, .myRule7 {
+  color: #ffffff;
+}
+
+.myRule8 {
+	display: block;
+}

--- a/test/fixtures/libraries/scopes/dom/lib1/dom/themes/foo/library.source.less
+++ b/test/fixtures/libraries/scopes/dom/lib1/dom/themes/foo/library.source.less
@@ -1,0 +1,7 @@
+div.myRule1 {
+  color: #000000;
+}
+
+div.myRule1 > .myRule2 {
+  color: #000000;
+}

--- a/test/fixtures/libraries/scopes/dom/lib2/dom/themes/bar/library.source.less
+++ b/test/fixtures/libraries/scopes/dom/lib2/dom/themes/bar/library.source.less
@@ -1,0 +1,7 @@
+div.myRule1 {
+  color: #ffffff;
+}
+
+div.myRule1 > .myRule2 {
+  color: #ffffff;
+}

--- a/test/fixtures/libraries/scopes/empty-media-queries/lib1/empty-media-queries/themes/foo/library.source.less
+++ b/test/fixtures/libraries/scopes/empty-media-queries/lib1/empty-media-queries/themes/foo/library.source.less
@@ -1,0 +1,9 @@
+.myRule1 {
+  color: #000000;
+}
+
+@media (min-width: 600px) and (max-width: 1023px) {
+	.myRule1 {
+	  width: 100px;
+	}
+}

--- a/test/fixtures/libraries/scopes/empty-media-queries/lib2/empty-media-queries/themes/bar/library.source.less
+++ b/test/fixtures/libraries/scopes/empty-media-queries/lib2/empty-media-queries/themes/bar/library.source.less
@@ -1,0 +1,9 @@
+.myRule1 {
+  color: #ffffff;
+}
+
+@media (min-width: 600px) and (max-width: 1023px) {
+	.myRule1 {
+	  width: 100px;
+	}
+}

--- a/test/fixtures/libraries/scopes/html/lib1/html/themes/foo/library.source.less
+++ b/test/fixtures/libraries/scopes/html/lib1/html/themes/foo/library.source.less
@@ -1,0 +1,16 @@
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid td > .sapUiFormTitle {
+  color: #000000;
+}
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid td > .sapUiFormTitle {
+  color: #000000;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .testClass {
+  color: #000000;
+}

--- a/test/fixtures/libraries/scopes/html/lib2/html/themes/bar/library.source.less
+++ b/test/fixtures/libraries/scopes/html/lib2/html/themes/bar/library.source.less
@@ -1,0 +1,16 @@
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie] .sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed] .sapUiGrid td > .sapUiFormTitle {
+  color: #ffffff;
+}
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ie].sapUiGrid td > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid th > .sapUiFormTitle,
+html[dir=rtl][data-sap-ui-browser^=ed].sapUiGrid td > .sapUiFormTitle {
+  color: #ffffff;
+}
+
+html[dir=rtl][data-sap-ui-browser^=ie].sap-desktop-sapUiClass .testClass {
+  color: #ffffff;
+}

--- a/test/fixtures/libraries/scopes/media-queries/lib1/media-queries/themes/foo/library.source.less
+++ b/test/fixtures/libraries/scopes/media-queries/lib1/media-queries/themes/foo/library.source.less
@@ -1,0 +1,40 @@
+@font-face {
+  font-family: 'myfont';
+  src: url('font.eot');
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+}
+
+@media (min-width: 600px) and (max-width: 1023px) {
+	.myRule1 {
+	  color: #000000;
+	}
+
+	.myRule2 {
+	  color: #ffffff;
+	}
+
+	.myRule3 {
+	  display: -webkit-flex;
+	  display: flex;
+	}
+
+	.sapMALI {
+	  display: -webkit-box;
+	  display: -moz-box;
+	  display: -ms-flexbox;
+	  display: flex;
+	}
+
+	.sapMALI .sapMLIBUnread,
+	.sapMALI .sapMLIBSelectS,
+	.sapMALI .sapMLIBSelectM,
+	.sapMALI .sapMLIBSelectD {
+	  display: none;
+	}
+
+	.sapMALI {
+	  height: 3rem;
+	}
+}

--- a/test/fixtures/libraries/scopes/media-queries/lib2/media-queries/themes/bar/library.source.less
+++ b/test/fixtures/libraries/scopes/media-queries/lib2/media-queries/themes/bar/library.source.less
@@ -1,0 +1,40 @@
+@font-face {
+  font-family: 'myfont';
+  src: url('font.eot');
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+}
+
+@media (min-width: 600px) and (max-width: 1023px) {
+	.myRule1 {
+	  color: #ffffff;
+	}
+
+	.myRule2 {
+	  color: #ffffff;
+	}
+
+	.myRule3 {
+	  display: -webkit-flex;
+	  display: flex;
+	}
+
+	.sapMALI {
+	  display: -webkit-box;
+	  display: -moz-box;
+	  display: -ms-flexbox;
+	  display: flex;
+	}
+
+	.sapMALI .sapMLIBUnread,
+	.sapMALI .sapMLIBSelectS,
+	.sapMALI .sapMLIBSelectM,
+	.sapMALI .sapMLIBSelectD {
+	  display: none;
+	}
+
+	.sapMALI {
+	  height: 3rem;
+	}
+}

--- a/test/fixtures/libraries/scopes/mixins/lib1/mixins/themes/foo/library.source.less
+++ b/test/fixtures/libraries/scopes/mixins/lib1/mixins/themes/foo/library.source.less
@@ -1,0 +1,10 @@
+@media screen and (min-width: 600px) {
+  body {
+    background: #000000;
+    font-size: 21px;
+  }
+
+  html.myRule1 td {
+    color: #000000;
+  }
+}

--- a/test/fixtures/libraries/scopes/mixins/lib2/mixins/themes/bar/library.source.less
+++ b/test/fixtures/libraries/scopes/mixins/lib2/mixins/themes/bar/library.source.less
@@ -1,0 +1,25 @@
+@media screen and (min-width: 600px) {
+   body {
+     background: #ffffff;
+     font-size: 20px;
+   }
+
+   html.myRule1 td {
+     color: #ffffff;
+   }
+}
+
+.myRule2 {
+  background: #ffffff;
+}
+
+@media screen and (min-width: 600px) {
+  body {
+    background: #ffffff;
+    font-size: 20px;
+  }
+
+  .myRule2 {
+    background: #ffffff;
+  }
+}

--- a/test/fixtures/libraries/scopes/multiple-imports/lib1/multiple-imports/themes/foo/library.source.less
+++ b/test/fixtures/libraries/scopes/multiple-imports/lib1/multiple-imports/themes/foo/library.source.less
@@ -1,0 +1,15 @@
+.myRule1 {
+  color: #ffffff;
+}
+
+.myRule2 {
+  display: block;
+}
+
+.myRule5 {
+  color: #ffffff;
+}
+
+.myRule6 {
+  display: block;
+}

--- a/test/fixtures/libraries/scopes/multiple-imports/lib2/multiple-imports/themes/bar/library.source.less
+++ b/test/fixtures/libraries/scopes/multiple-imports/lib2/multiple-imports/themes/bar/library.source.less
@@ -1,0 +1,27 @@
+.myRule1 {
+  color: #ffffff;
+}
+
+.myRule2 {
+  display: block;
+}
+
+.myRule3 {
+  color: red;
+}
+
+.myRule4 {
+  background-color: transparent !important;
+}
+
+.myRule5 {
+  color: #ffffff;
+}
+
+.myRule6 {
+  display: block;
+}
+
+.myRule7 {
+  color: red;
+}


### PR DESCRIPTION
- Introduced "Builder" class to enable caching of build results
- Added "lessInputPath" option to provide a path relative to the "rootPaths"
- Added diffing and scoping to support Belize contrast areas
- Analyze .theming files as theme scope indicators
- Added new tests