### PR TITLE
Revert "Fix inline theme parameters encoding for '#'"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -248,7 +248,7 @@ Builder.prototype.build = function(options) {
 				var parameters = JSON.stringify(result.variables);
 
 				// escape all chars that could cause problems with css parsers using URI-Encoding (% + HEX-Code)
-				var escapedChars = "%{}()'\"\\#";
+				var escapedChars = "%{}()'\"\\";
 				for (var i = 0; i < escapedChars.length; i++) {
 					var char = escapedChars.charAt(i);
 					var hex = char.charCodeAt(0).toString(16).toUpperCase();

--- a/test/expected/libraries/lib1/my/ui/lib/themes/base/library-RTL.css
+++ b/test/expected/libraries/lib1/my/ui/lib/themes/base/library-RTL.css
@@ -6,4 +6,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22color1%22:%22%23fefefe%22%7D'); }
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22color1%22:%22#fefefe%22%7D'); }

--- a/test/expected/libraries/lib1/my/ui/lib/themes/base/library.css
+++ b/test/expected/libraries/lib1/my/ui/lib/themes/base/library.css
@@ -6,4 +6,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22color1%22:%22%23fefefe%22%7D'); }
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22color1%22:%22#fefefe%22%7D'); }

--- a/test/expected/libraries/lib1/my/ui/lib/themes/foo/library-RTL.css
+++ b/test/expected/libraries/lib1/my/ui/lib/themes/foo/library-RTL.css
@@ -10,4 +10,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22%23ffffff%22%7D,%22scopes%22:%7B%22fooContrast%22:%7B%22color1%22:%22%23000000%22%7D%7D%7D'); }
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22#ffffff%22%7D,%22scopes%22:%7B%22fooContrast%22:%7B%22color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/libraries/lib1/my/ui/lib/themes/foo/library.css
+++ b/test/expected/libraries/lib1/my/ui/lib/themes/foo/library.css
@@ -10,4 +10,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22%23ffffff%22%7D,%22scopes%22:%7B%22fooContrast%22:%7B%22color1%22:%22%23000000%22%7D%7D%7D'); }
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22#ffffff%22%7D,%22scopes%22:%7B%22fooContrast%22:%7B%22color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/libraries/lib2/my/ui/lib/themes/bar/library-RTL.css
+++ b/test/expected/libraries/lib2/my/ui/lib/themes/bar/library-RTL.css
@@ -10,4 +10,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22%23ffffff%22%7D,%22scopes%22:%7B%22barContrast%22:%7B%22color1%22:%22%23000000%22%7D%7D%7D'); }
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22#ffffff%22%7D,%22scopes%22:%7B%22barContrast%22:%7B%22color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/libraries/lib2/my/ui/lib/themes/bar/library.css
+++ b/test/expected/libraries/lib2/my/ui/lib/themes/bar/library.css
@@ -10,4 +10,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22%23ffffff%22%7D,%22scopes%22:%7B%22barContrast%22:%7B%22color1%22:%22%23000000%22%7D%7D%7D'); }
+#sap-ui-theme-my\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22color1%22:%22#ffffff%22%7D,%22scopes%22:%7B%22barContrast%22:%7B%22color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/libraries/lib3/my/other/ui/lib/themes/bar/library-RTL.css
+++ b/test/expected/libraries/lib3/my/other/ui/lib/themes/bar/library-RTL.css
@@ -10,4 +10,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22%23ffffff%22,%22_my_other_ui_lib_MyControl_color2%22:%22%23008000%22%7D,%22scopes%22:%7B%22barContrast%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22%23000000%22%7D%7D%7D'); }
+#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22#ffffff%22,%22_my_other_ui_lib_MyControl_color2%22:%22#008000%22%7D,%22scopes%22:%7B%22barContrast%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/libraries/lib3/my/other/ui/lib/themes/bar/library.css
+++ b/test/expected/libraries/lib3/my/other/ui/lib/themes/bar/library.css
@@ -10,4 +10,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22%23ffffff%22,%22_my_other_ui_lib_MyControl_color2%22:%22%23008000%22%7D,%22scopes%22:%7B%22barContrast%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22%23000000%22%7D%7D%7D'); }
+#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22#ffffff%22,%22_my_other_ui_lib_MyControl_color2%22:%22#008000%22%7D,%22scopes%22:%7B%22barContrast%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/libraries/lib3/my/other/ui/lib/themes/base/library-RTL.css
+++ b/test/expected/libraries/lib3/my/other/ui/lib/themes/base/library-RTL.css
@@ -6,4 +6,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22_my_other_ui_lib_MyControl_color1%22:%22%23fefefe%22%7D'); }
+#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22_my_other_ui_lib_MyControl_color1%22:%22#fefefe%22%7D'); }

--- a/test/expected/libraries/lib3/my/other/ui/lib/themes/base/library.css
+++ b/test/expected/libraries/lib3/my/other/ui/lib/themes/base/library.css
@@ -6,4 +6,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22_my_other_ui_lib_MyControl_color1%22:%22%23fefefe%22%7D'); }
+#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22_my_other_ui_lib_MyControl_color1%22:%22#fefefe%22%7D'); }

--- a/test/expected/libraries/lib3/my/other/ui/lib/themes/foo/library-RTL.css
+++ b/test/expected/libraries/lib3/my/other/ui/lib/themes/foo/library-RTL.css
@@ -10,4 +10,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22%23ffffff%22,%22_my_other_ui_lib_MyControl_color2%22:%22%23008000%22%7D,%22scopes%22:%7B%22fooContrast%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22%23000000%22%7D%7D%7D'); }
+#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22#ffffff%22,%22_my_other_ui_lib_MyControl_color2%22:%22#008000%22%7D,%22scopes%22:%7B%22fooContrast%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/libraries/lib3/my/other/ui/lib/themes/foo/library.css
+++ b/test/expected/libraries/lib3/my/other/ui/lib/themes/foo/library.css
@@ -10,4 +10,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22%23ffffff%22,%22_my_other_ui_lib_MyControl_color2%22:%22%23008000%22%7D,%22scopes%22:%7B%22fooContrast%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22%23000000%22%7D%7D%7D'); }
+#sap-ui-theme-my\.other\.ui\.lib { background-image: url('data:text/plain;utf-8,%7B%22default%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22#ffffff%22,%22_my_other_ui_lib_MyControl_color2%22:%22#008000%22%7D,%22scopes%22:%7B%22fooContrast%22:%7B%22_my_other_ui_lib_MyControl_color1%22:%22#000000%22%7D%7D%7D'); }

--- a/test/expected/simple/test-inline-parameters.css
+++ b/test/expected/simple/test-inline-parameters.css
@@ -4,4 +4,4 @@
 }
 
 /* Inline theming parameters */
-#sap-ui-theme-foo\.bar { background-image: url('data:text/plain;utf-8,%7B%22myColor%22:%22%23ff0000%22%7D'); }
+#sap-ui-theme-foo\.bar { background-image: url('data:text/plain;utf-8,%7B%22myColor%22:%22#ff0000%22%7D'); }


### PR DESCRIPTION
Reverts SAP/less-openui5#23

Reverting this as it currently breaks the runtime and needs additional decoding within sap.ui.core.theming.Parameters.