### PR TITLE
package.json: Define files to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "type": "git",
     "url": "https://github.com/SAP/less-openui5.git"
   },
+  "files": [
+    "CONTRIBUTING.md",
+    "lib/**"
+  ],
   "keywords": [
     "less",
     "less.js",


### PR DESCRIPTION
This will help reduce the size of the published less-openui5 package