### PR TITLE
Adapt node themebuild to maven build

### DIFF
--- a/lib/scope.js
+++ b/lib/scope.js
@@ -101,6 +101,9 @@ Scoping.prototype.scopeRules = function(oRules) {
 					if (sSelector2) {
 						aNewSelectors.push(sSelector2);
 					}
+				} else {
+					// scope name already exists
+					aNewSelectors.push(sSelector);
 				}
 			}
 

--- a/test/expected/libraries/scopes/default/lib2/default/themes/bar/library-RTL.css
+++ b/test/expected/libraries/scopes/default/lib2/default/themes/bar/library-RTL.css
@@ -41,3 +41,15 @@
 .myRule8 {
   display: block;
 }
+
+.sapContrast .sapMNLI {
+  background: #000000;
+}
+
+.sapContrast .sapMNLG-GroupHeader {
+  background: #000000;
+}
+
+.sapContrast .sapMNLG-Body .sapMNLI {
+  background: #000000;
+}

--- a/test/expected/libraries/scopes/default/lib2/default/themes/bar/library.css
+++ b/test/expected/libraries/scopes/default/lib2/default/themes/bar/library.css
@@ -41,3 +41,15 @@
 .myRule8 {
   display: block;
 }
+
+.sapContrast .sapMNLI {
+  background: #000000;
+}
+
+.sapContrast .sapMNLG-GroupHeader {
+  background: #000000;
+}
+
+.sapContrast .sapMNLG-Body .sapMNLI {
+  background: #000000;
+}

--- a/test/fixtures/libraries/scopes/default/lib2/default/themes/bar/library.source.less
+++ b/test/fixtures/libraries/scopes/default/lib2/default/themes/bar/library.source.less
@@ -26,3 +26,18 @@
 .myRule8 {
 	display: block;
 }
+
+.sapContrast {
+  .sapMNLI {
+	background: #000000;
+  }
+  .sapMNLG-GroupHeader {
+	background: #000000;
+  }
+
+  .sapMNLG-Body {
+	.sapMNLI {
+		background:  darken(#000000,5);
+	}
+  }
+}


### PR DESCRIPTION
CSS selectors having the scope name added manually (like e.g. in sap/m/BarBase.less) where ignored.