### PR TITLE
[FIX][WIP] css compression option invalid calc

### DIFF
--- a/test/expected/minification/test.css
+++ b/test/expected/minification/test.css
@@ -1,0 +1,1 @@
+.supi:not(.thehe) .meinnerle{margin-right:calc(0px + .25rem)}.supi:not(.thehe) .myele{margin-right:0}

--- a/test/fixtures/minification/test.less
+++ b/test/fixtures/minification/test.less
@@ -1,0 +1,22 @@
+@_sap_ui_table_RowActionColumnWidth: 0.25rem;
+
+
+._sapUiTableVScrWithActionsInnerMixin_CalcMarginRight(@ScrollbarSize, @RowActionWidth) {
+  margin-right: calc(@ScrollbarSize ~"+" @RowActionWidth);
+}
+
+._sapUiTableVScrWithActionsInnerMixin(@ScrollbarSize, @RowActionWidth) {
+
+  .meinnerle {
+    ._sapUiTableVScrWithActionsInnerMixin_CalcMarginRight(@ScrollbarSize, @RowActionWidth);
+  }
+
+  .myele {
+    margin-right: @ScrollbarSize;
+  }
+}
+
+.supi:not(.thehe) {
+  ._sapUiTableVScrWithActionsInnerMixin(0px, @_sap_ui_table_RowActionColumnWidth);
+}
+

--- a/test/test-minification.js
+++ b/test/test-minification.js
@@ -1,0 +1,37 @@
+// Copyright 2019 SAP SE.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http: //www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific
+// language governing permissions and limitations under the License.
+
+/* eslint-env mocha */
+"use strict";
+
+const assert = require("assert");
+const readFile = require("./common/helper").readFile;
+
+// tested module
+const Builder = require("../").Builder;
+
+describe("minification", function() {
+	it("minify", function() {
+		return new Builder().build({
+			lessInput: readFile("test/fixtures/minification/test.less"),
+			compiler: {
+				compress: true
+			}
+		}).then(function(result) {
+			assert.equal(result.css, readFile("test/expected/minification/test.css"), "css should be correctly generated.");
+		}, function(err) {
+			console.error(err);
+		});
+	});
+});


### PR DESCRIPTION
Chrome browser does not support calc with `0`, e.g.
`margin-right: calc(0 + 2rem)`
Add test case