### PR TITLE
[FIX] CSS var assignment only for less to less vars

### DIFF
--- a/lib/plugin/css-variables-pointer.js
+++ b/lib/plugin/css-variables-pointer.js
@@ -62,9 +62,23 @@ CSSVariablesPointerPlugin.prototype = {
 		return node;
 	},
 
+	_isVariableAssignment(rule) {
+		// determines a simple less variable assignment:
+		// Rule > Value => Array[length=1] > Expression => Array[length=1] > Variable
+		const value = rule && rule.variable && rule.value instanceof less.tree.Value && rule.value;
+		const expression = value &&
+			Array.isArray(value.value) && value.value.length == 1 &&
+			value.value[0] instanceof less.tree.Expression && value.value[0];
+		const variable = expression &&
+			Array.isArray(expression.value) && expression.value.length == 1 &&
+			expression.value[0] instanceof less.tree.Variable && expression.value[0];
+		return variable;
+	},
+
 	visitVariable(node, visitArgs) {
-		// collect less variables to css variables mapping
-		if (this.callStack.length == 0 && this.ruleStack.length > 0 && this.ruleStack[this.ruleStack.length - 1].variable) {
+		// collect all simple less variables to less variables mapping (to convert them to css variables assignments)
+		if (this.callStack.length == 0 && this.ruleStack.length > 0 &&
+			this._isVariableAssignment(this.ruleStack[this.ruleStack.length - 1])) {
 			this.mVars["--" + this.ruleStack[0].name.substr(1)] = "var(" + node.name.replace(/^@/, "--") + ")";
 		}
 		return node;

--- a/lib/plugin/css-variables-pointer.js
+++ b/lib/plugin/css-variables-pointer.js
@@ -65,7 +65,8 @@ CSSVariablesPointerPlugin.prototype = {
 	_isVariableAssignment(rule) {
 		// determines a simple less variable assignment:
 		// Rule > Value => Array[length=1] > Expression => Array[length=1] > Variable
-		const value = rule && rule.variable && rule.value instanceof less.tree.Value && rule.value;
+		const value = rule && rule.variable &&
+			rule.value instanceof less.tree.Value && rule.value;
 		const expression = value &&
 			Array.isArray(value.value) && value.value.length == 1 &&
 			value.value[0] instanceof less.tree.Expression && value.value[0];

--- a/test/expected/complex/test-cssvars-variables.css
+++ b/test/expected/complex/test-cssvars-variables.css
@@ -1,6 +1,7 @@
 :root {
   --link-color: #428bca;
   --link-color-hover: #3071a9;
+  --other-var: 0 0 0.25rem 0 rgba(0, 0, 0, 0.15), inset 0 -0.0625rem 0 0 #428bca;
   --link-color-active: var(--link-color);
   --var: var(--a);
   --a: 9%;

--- a/test/fixtures/complex/test.less
+++ b/test/fixtures/complex/test.less
@@ -1,6 +1,7 @@
 // Variables
 @link-color:        #428bca; // sea blue
 @link-color-hover:  darken(@link-color, 10%);
+@other-var: 0 0 0.25rem 0 rgba(0, 0, 0, 0.15), inset 0 -0.0625rem 0 0 @link-color;
 @link-color-active: @link-color;
 
 // Usage


### PR DESCRIPTION
In case of more complex expressions as value of a rule, the css variable mapping logic detects this also as simple variable assignment. Therefore we need to introduce a more complex check for a simple variable assignment in the less code:

```text
/resources/sap/ui/core/themes/sap_fiori_3/css-variables.css

SOURCE:
@sapUiShadowHeader: 0 0 0.25rem 0 fade(@sapUiContentShadowColor, 15), inset 0 -0.0625rem 0 0 @sapUiObjectHeaderBorderColor;

WAS (before var assignment feature):
--sapUiShadowHeader:0 0 .25rem 0 rgba(0,0,0,0.15),inset 0 -0.0625rem 0 0 #d9d9d9;

IS (with that var assignment feature):
--sapUiShadowHeader:var(--sapUiObjectHeaderBorderColor);

BECOMES (with this fix here):
--sapUiShadowHeader:0 0 .25rem 0 rgba(0,0,0,0.15),inset 0 -0.0625rem 0 0 #d9d9d9;

```