### PR TITLE
[FIX] Switch to maintained fork of "css" package

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const css = require("css");
+const css = require("@adobe/css-tools");;
 
 
 const diff = require("./diff");

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const css = require("@adobe/css-tools");;
+const css = require("@adobe/css-tools");
 
 
 const diff = require("./diff");

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.11.5",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@adobe/css-tools": "^4.0.2",
 				"clone": "^2.1.2",
-				"css": "^3.0.0",
 				"mime": "^1.6.0"
 			},
 			"devDependencies": {
@@ -26,6 +26,11 @@
 				"node": ">= 10",
 				"npm": ">= 5"
 			}
+		},
+		"node_modules/@adobe/css-tools": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.2.tgz",
+			"integrity": "sha512-Fx6tYjk2wKUgLi8uMANZr8GNZx05u44ArIJldn9VxLvolzlJVgHbTUCbwhMd6bcYky178+WUSxPHO3DAtGLWpw=="
 		},
 		"node_modules/@ampproject/remapping": {
 			"version": "2.2.0",
@@ -893,17 +898,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/atob": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-			"bin": {
-				"atob": "bin/atob.js"
-			},
-			"engines": {
-				"node": ">= 4.5.0"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1165,16 +1159,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/css": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-			"integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-			"dependencies": {
-				"inherits": "^2.0.4",
-				"source-map": "^0.6.1",
-				"source-map-resolve": "^0.6.0"
-			}
-		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1199,14 +1183,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decode-uri-component": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-			"engines": {
-				"node": ">=0.10"
 			}
 		},
 		"node_modules/deep-is": {
@@ -2060,7 +2036,8 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"node_modules/invariant": {
 			"version": "2.2.4",
@@ -3750,6 +3727,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3761,16 +3739,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/source-map-resolve": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-			"integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-			"deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
-			"dependencies": {
-				"atob": "^2.1.2",
-				"decode-uri-component": "^0.2.0"
 			}
 		},
 		"node_modules/sourcemap-codec": {
@@ -4290,6 +4258,11 @@
 		}
 	},
 	"dependencies": {
+		"@adobe/css-tools": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.0.2.tgz",
+			"integrity": "sha512-Fx6tYjk2wKUgLi8uMANZr8GNZx05u44ArIJldn9VxLvolzlJVgHbTUCbwhMd6bcYky178+WUSxPHO3DAtGLWpw=="
+		},
 		"@ampproject/remapping": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -4968,11 +4941,6 @@
 			"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
 			"dev": true
 		},
-		"atob": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
-		},
 		"balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -5169,16 +5137,6 @@
 				"which": "^2.0.1"
 			}
 		},
-		"css": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
-			"integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
-			"requires": {
-				"inherits": "^2.0.4",
-				"source-map": "^0.6.1",
-				"source-map-resolve": "^0.6.0"
-			}
-		},
 		"debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -5193,11 +5151,6 @@
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
 			"dev": true
-		},
-		"decode-uri-component": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
 		},
 		"deep-is": {
 			"version": "0.1.4",
@@ -5829,7 +5782,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"invariant": {
 			"version": "2.2.4",
@@ -7113,22 +7067,14 @@
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true
 		},
 		"source-map-js": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"dev": true
-		},
-		"source-map-resolve": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
-			"integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
-			"requires": {
-				"atob": "^2.1.2",
-				"decode-uri-component": "^0.2.0"
-			}
 		},
 		"sourcemap-codec": {
 			"version": "1.4.8",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
 		"url": "git@github.com:SAP/less-openui5.git"
 	},
 	"dependencies": {
+		"@adobe/css-tools": "^4.0.2",
 		"clone": "^2.1.2",
-		"css": "^3.0.0",
 		"mime": "^1.6.0"
 	},
 	"devDependencies": {

--- a/test/test-diff.js
+++ b/test/test-diff.js
@@ -2,7 +2,7 @@
 "use strict";
 
 const assert = require("assert");
-const css = require("@adobe/css-tools");;
+const css = require("@adobe/css-tools");
 const fs = require("fs");
 const path = require("path");
 

--- a/test/test-diff.js
+++ b/test/test-diff.js
@@ -2,7 +2,7 @@
 "use strict";
 
 const assert = require("assert");
-const css = require("css");
+const css = require("@adobe/css-tools");;
 const fs = require("fs");
 const path = require("path");
 


### PR DESCRIPTION
This had been first attempted in 0abe66a but later reverted by 3b6c459
due to https://github.com/adobe/css-tools/issues/77, reapplying since
the issue is now fixed.

---

This solves the issue of having outdated and potential insecure
transitive dependencies.

There are no known behavior changes, so this is considered a
non-breaking change / fix.

See: reworkcss/css#163
See: SamVerschueren/decode-uri-component#6
