### PR TITLE
[INTERNAL] package.json: Move postversion git push to prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"test": "npm run lint && npm run coverage && npm run depcheck",
 		"preversion": "npm test",
 		"version": "git-chglog --next-tag v$npm_package_version -o CHANGELOG.md 0.7.0.. && git add CHANGELOG.md",
-		"postversion": "git push --follow-tags",
+		"prepublishOnly": "git push --follow-tags",
 		"release-note": "git-chglog -c .chglog/release-config.yml v$npm_package_version",
 		"depcheck": "depcheck --ignores clean-css,source-map"
 	},


### PR DESCRIPTION
This allows our CI to do some final validation between "npm version" and
"npm publish". I.e. validating the reduced npm-shrinkwrap-json that is
created after "npm version" created the release commit".

Related change: https://github.com/SAP/ui5-cli/pull/321