### PR TITLE
[FIX] fileUtils: Correctly provide stat property on readFile result and properly handle exceptions from fs.stat

### DIFF
--- a/lib/fileUtils.js
+++ b/lib/fileUtils.js
@@ -10,8 +10,14 @@ module.exports = function(fs) {
 	function statFile(filePath) {
 		return new Promise(function(resolve, reject) {
 			fs.stat(filePath, function(err, stat) {
-				// No rejection here as it is ok if the file was not found
-				resolve(stat ? {path: filePath, stat: stat} : null);
+				if (err) {
+					if (err.code === "ENOENT") { // "File or directory does not exist"
+						return resolve(null);
+					} else {
+						return reject(err);
+					}
+				}
+				resolve({path: filePath, stat});
 			});
 		});
 	}


### PR DESCRIPTION
The fileInfo object contains property 'stat', not 'stats'. I couldn't find any usage of the property on the readFile result though.

Also, do not assume every fs.stat exception is caused by a missing file.

**NOTE:** UI5 Tooling v4 relies on the current behavior in the sense that it does not always pass an `ENOENT` error code to the less-openui5 file system callback. Therefore this should be released as part of a new minor version of less-openui5 (implying a breaking change).