### PR TITLE
[INTERNAL] Harden workflows

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.auto_merge == null }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.auto_merge == null }}
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
Replace spoofable github.actor check in dependabot-auto-merge with
github.event.pull_request.user.login. Note: spoofing the dependabot
actor alone is not sufficient to trigger the auto-merge step. The
dependabot/fetch-metadata action only emits outputs for genuine
dependabot PRs, so the merge step's check on
steps.metadata.outputs.update-type would no-op on a spoofed run. The
change closes the gap defensively.
