### PR TITLE
[FIX] Replace "clone" dependency with built-in structuredClone

### DIFF
--- a/lib/Compiler.js
+++ b/lib/Compiler.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const createParser = require("./less/parser");
-const clone = require("clone");
 
 // Plugins
 const ImportCollectorPlugin = require("./plugin/import-collector");
@@ -56,7 +55,7 @@ class Compiler {
 		};
 	}
 	async compile(config) {
-		const parserOptions = clone(this.options.parser);
+		const parserOptions = structuredClone(this.options.parser);
 		let rootpath;
 
 		if (config.path) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@adobe/css-tools": "^4.5.0",
-				"clone": "^2.1.2",
 				"mime": "^1.6.0"
 			},
 			"devDependencies": {
@@ -1604,15 +1603,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8"
 			}
 		},
 		"node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
 	},
 	"dependencies": {
 		"@adobe/css-tools": "^4.5.0",
-		"clone": "^2.1.2",
 		"mime": "^1.6.0"
 	},
 	"devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -4,8 +4,19 @@
 const assert = require("assert");
 const sinon = require("sinon");
 const path = require("path");
-const clone = require("clone");
 const readFile = require("./common/helper").readFile;
+
+// Deep clone that preserves function references. structuredClone can't be used here
+// because the theme cache holds compiled less functions, which are not serializable.
+function deepClone(value) {
+	if (Array.isArray(value)) {
+		return value.map(deepClone);
+	}
+	if (value && typeof value === "object") {
+		return Object.fromEntries(Object.entries(value).map(([key, val]) => [key, deepClone(val)]));
+	}
+	return value;
+}
 
 // tested module
 const Builder = require("../").Builder;
@@ -813,13 +824,13 @@ describe("theme caching", function() {
 		const builder = new Builder();
 
 		return builder.build(lessOptions).then(function(res) {
-			const cacheFirstRun = clone(builder.themeCacheMapping);
+			const cacheFirstRun = deepClone(builder.themeCacheMapping);
 
 			assert.notDeepEqual(cacheFirstRun, {}, "themeCache should not be empty.");
 
 			// second run
 			return builder.build(lessOptions).then(function(result) {
-				const cacheSecondRun = clone(builder.themeCacheMapping);
+				const cacheSecondRun = deepClone(builder.themeCacheMapping);
 
 				assert.deepEqual(res, result, "callback result should be the same");
 
@@ -845,7 +856,7 @@ describe("theme caching", function() {
 		const builder = new Builder();
 
 		return builder.build(lessOptions).then(function(res) {
-			const cacheFirstRun = clone(builder.themeCacheMapping);
+			const cacheFirstRun = deepClone(builder.themeCacheMapping);
 
 			assert.notDeepEqual(cacheFirstRun, {}, "themeCache should not be empty.");
 
@@ -855,7 +866,7 @@ describe("theme caching", function() {
 
 			// second run
 			return builder.build(lessOptions).then(function(result) {
-				const cacheSecondRun = clone(builder.themeCacheMapping);
+				const cacheSecondRun = deepClone(builder.themeCacheMapping);
 
 				assert.equal(JSON.stringify(res, null, 4), JSON.stringify(result, null, 4), "callback result should be the same");
 


### PR DESCRIPTION
The parser options passed to structuredClone are always plain serializable data, and structuredClone is available on all supported Node.js versions (>=20.11).

JIRA: CPOUI5FOUNDATION-1293