### PR TITLE
[FIX] Drop deprecated `url.parse()`

### DIFF
--- a/lib/plugin/rtl.js
+++ b/lib/plugin/rtl.js
@@ -2,7 +2,7 @@
 
 const less = require("../thirdparty/less");
 const path = require("path");
-const url = require("url");
+const {isAbsoluteUrl} = require("./util");
 
 const cssSizePattern = /(-?[.0-9]+)([a-z]*)/;
 const percentagePattern = /^\s*(-?[.0-9]+)%\s*$/;
@@ -619,9 +619,8 @@ LessRtlPlugin.prototype = {
 		}
 		modifyOnce(node, "replaceUrl", (urlNode) => {
 			const imgPath = urlNode.value.value;
-			const parsedUrl = url.parse(imgPath);
-			if (parsedUrl.protocol || imgPath.startsWith("/")) {
-				// Ignore absolute urls
+			if (isAbsoluteUrl(imgPath)) {
+				// Ignore urls with a scheme (http:, data:, etc.) and server-absolute urls.
 				return;
 			}
 			const imgPathRTL = LessRtlPlugin.getRtlImgUrl(imgPath);

--- a/lib/plugin/url-collector.js
+++ b/lib/plugin/url-collector.js
@@ -1,8 +1,8 @@
 "use strict";
 
 const path = require("path");
-const url = require("url");
 const less = require("../thirdparty/less");
+const {isAbsoluteUrl} = require("./util");
 
 const urlNodeNames = {
 	"background": true,
@@ -48,10 +48,8 @@ UrlCollectorPlugin.prototype = {
 		if (node.type === "Url") {
 			const relativeUrl = node.value.value;
 
-			const parsedUrl = url.parse(relativeUrl);
-			// Ignore urls with protocol (also includes data urls)
-			// Ignore server absolute urls
-			if (parsedUrl.protocol || relativeUrl.startsWith("/")) {
+			// Ignore urls with a scheme (http:, data:, etc.) and server-absolute urls.
+			if (isAbsoluteUrl(relativeUrl)) {
 				return;
 			}
 

--- a/lib/plugin/util.js
+++ b/lib/plugin/util.js
@@ -1,0 +1,20 @@
+"use strict";
+
+/**
+ * Checks whether a CSS url() value should be treated as absolute, i.e. must not be resolved
+ * relative to the current file. This covers urls carrying a scheme (http:, https:, data:, ...)
+ * as well as server-absolute urls starting with "/".
+ *
+ * URL.canParse only succeeds for absolute urls (those with a scheme), so relative urls return
+ * false.
+ *
+ * @param {string} value the url value as taken from the CSS url() node
+ * @returns {boolean} true if the url is absolute and should not be resolved relatively
+ */
+function isAbsoluteUrl(value) {
+	return URL.canParse(value) || value.startsWith("/");
+}
+
+module.exports = {
+	isAbsoluteUrl
+};

--- a/test/lib/plugin/util.js
+++ b/test/lib/plugin/util.js
@@ -1,0 +1,46 @@
+/* eslint-env mocha */
+"use strict";
+
+const assert = require("assert");
+
+// tested module
+const {isAbsoluteUrl} = require("../../../lib/plugin/util");
+
+describe("plugin/util#isAbsoluteUrl", function() {
+	[
+		// Urls carrying a scheme => absolute
+		"http://example.com/img/a.png",
+		"https://example.com/img/a.png",
+		"data:image/png;base64,iVBORw0KGgoAAAAN",
+		"mailto:someone@example.com",
+		"custom-scheme://x",
+		// Leading whitespace before the scheme is trimmed
+		"\tdata:image/png;base64,iVBORw0KGgoAAAAN",
+		"  data:image/png;base64,iVBORw0KGgoAAAAN",
+		// Server-absolute urls => absolute
+		"/server/absolute/img.png",
+		// Protocol-relative urls have no scheme but start with "/" => absolute
+		"//example.com/img/a.png"
+	].forEach(function(url) {
+		it(`should treat ${JSON.stringify(url)} as absolute`, function() {
+			assert.strictEqual(isAbsoluteUrl(url), true);
+		});
+	});
+
+	[
+		// Relative urls => not absolute
+		"img/foo.png",
+		"chess.png",
+		"./img/foo.png",
+		"../img/foo.png",
+		"",
+		// Malformed schemes (scheme must not start with a digit or "+") => treated as relative.
+		// url.parse() accepted these loosely; URL.canParse() correctly rejects them.
+		"1abc:x",
+		"+foo:x"
+	].forEach(function(url) {
+		it(`should treat ${JSON.stringify(url)} as relative`, function() {
+			assert.strictEqual(isAbsoluteUrl(url), false);
+		});
+	});
+});

--- a/test/test-url-collector-plugin.js
+++ b/test/test-url-collector-plugin.js
@@ -105,6 +105,65 @@ describe("UrlCollectorPlugin", function() {
 		});
 	});
 
+	it("should not collect data-urls with leading whitespace", function() {
+		// The URL scheme detection must trim leading whitespace/control chars before looking
+		// for the scheme.
+		return new Builder().build({
+			lessInput: `
+.rule {
+	background-image: url("\tdata:image/png;base64,iVBORw0KGgoAAAAN");
+}
+			`,
+		}).then(function(/* result */) {
+			const collectedUrls = getUrlsSpy.getCall(0).returnValue;
+			assert.deepEqual(collectedUrls, []);
+		});
+	});
+
+	it("should not collect urls with a protocol", function() {
+		return new Builder().build({
+			lessInput: `
+.rule1 {
+	background-image: url(http://example.com/img/a.png);
+}
+.rule2 {
+	background-image: url(https://example.com/img/b.png);
+}
+			`,
+		}).then(function(/* result */) {
+			const collectedUrls = getUrlsSpy.getCall(0).returnValue;
+			assert.deepEqual(collectedUrls, []);
+		});
+	});
+
+	it("should not collect server-absolute urls", function() {
+		return new Builder().build({
+			lessInput: `
+.rule {
+	background-image: url(/server/absolute/img.png);
+}
+			`,
+		}).then(function(/* result */) {
+			const collectedUrls = getUrlsSpy.getCall(0).returnValue;
+			assert.deepEqual(collectedUrls, []);
+		});
+	});
+
+	it("should not collect protocol-relative urls", function() {
+		// A protocol-relative url ("//host/...") has no scheme but starts with "/", so it is
+		// ignored as a server-absolute url.
+		return new Builder().build({
+			lessInput: `
+.rule {
+	background-image: url(//example.com/img/a.png);
+}
+			`,
+		}).then(function(/* result */) {
+			const collectedUrls = getUrlsSpy.getCall(0).returnValue;
+			assert.deepEqual(collectedUrls, []);
+		});
+	});
+
 	it("should not fail on empty url", function() {
 		return new Builder().build({
 			lessInput: `

--- a/test/test.js
+++ b/test/test.js
@@ -722,6 +722,36 @@ describe("img-RTL check", function() {
 
 		// NOTE: cssVariables are currently LTR only. There is no RTL-variant.
 	});
+
+	it("Do not rewrite urls with a scheme", async () => {
+		const builder = new Builder();
+
+		// findFile must never be consulted for scheme-carrying urls, they are ignored up front.
+		const findFileStub = sinon.stub(builder.fileUtils, "findFile");
+		findFileStub.rejects(new Error("Unexpected call"));
+
+		const result = await builder.build({
+			lessInput: `
+				.rule {
+					background: url(http://example.com/img/test.png);
+					list-style-image: url(data:image/png;base64,iVBORw0KGgoAAAAN);
+					cursor: url("\tdata:image/png;base64,iVBORw0KGgoAAAAN");
+				}
+			`,
+			parser: {
+				filename: "foo/bar.less"
+			}
+		});
+
+		const expected = `.rule {
+  background: url(http://example.com/img/test.png);
+  list-style-image: url(data:image/png;base64,iVBORw0KGgoAAAAN);
+  cursor: url("\tdata:image/png;base64,iVBORw0KGgoAAAAN");
+}
+`;
+		assert.equal(result.css, expected, "css should be generated as expected");
+		assert.equal(result.cssRtl, expected, "rtl css should not rewrite scheme urls");
+	});
 });
 
 describe("variables", function() {


### PR DESCRIPTION
API has been deprecated with Node.js v24.0.0 in favor of the WHATWG URL API.